### PR TITLE
feat: add settings model and endpoints

### DIFF
--- a/src/controllers/admin.js
+++ b/src/controllers/admin.js
@@ -1,52 +1,59 @@
 /**=================================================================
- * ====   TITLE::     ADDING ADMIN FORGOT AND RESET PASSWORD    ====  
+ * ====   TITLE::     ADDING ADMIN FORGOT AND RESET PASSWORD    ====
  * ====   AUTHOR:: jimoh19 <jemohkunle2007@gmail.com>           ====
  * ====   DATE::            30TH JUNE 2020                      ====
  * =================================================================
  */
 
-const CustomResponse = require('../utils/response');
-const AdminSrv = require('../services/adminAuth');
+const CustomResponse = require("../utils/response");
+const AdminSrv = require("../services/adminAuth");
 
-class AdminController{
-
+class AdminController {
   async register(request, response) {
-  
     const data = await AdminSrv.register(request.body);
-    return response.status(201).json(CustomResponse('Registration successful', data));
-
+    return response
+      .status(201)
+      .json(CustomResponse("Registration successful", data));
   } //end register
 
-  async getKey(request, response){
-  
+  async getKey(request, response) {
     const data = await AdminSrv.getKey(request.body);
     return response.status(200).json(CustomResponse(data.message, data.data));
-
   } //end getKey
 
-  async forgotPassword(request, response){
+  async getSettings(request, response) {
+    const data = await AdminSrv.getSettings(request.body);
+    return response.status(200).json(CustomResponse(data.message, data.data));
+  } //end getSettings
 
+  async updateSettings(request, response) {
+    const data = await AdminSrv.updateSettings(request.body);
+    return response.status(200).json(CustomResponse(data.message, data.data));
+  } //end getSettings
+
+  async forgotPassword(request, response) {
     const data = await AdminSrv.forgotPassword(request);
-    return response.status(200).json(CustomResponse(`A password reset link has been sent to ${data.email}`));
-
+    return response
+      .status(200)
+      .json(
+        CustomResponse(`A password reset link has been sent to ${data.email}`)
+      );
   } //end forgotPassword
 
-  async resetPassword(request, response){
-    
+  async resetPassword(request, response) {
     const data = await AdminSrv.resetPassword(request);
-    return response.status(200).json(CustomResponse('Password updated successfully. You may login'));
-
+    return response
+      .status(200)
+      .json(CustomResponse("Password updated successfully. You may login"));
   } //end resetPassword
 
-  async deactivateUser(req,res){
-
+  async deactivateUser(req, res) {
     const data = await AdminSrv.deactivateUser(req);
-    res.status(data.code).send(CustomResponse('User has been successfully deactivated', data));
-
-  } //end deactivateUser  
-
+    res
+      .status(data.code)
+      .send(CustomResponse("User has been successfully deactivated", data));
+  } //end deactivateUser
 } //end class
-
 
 module.exports = new AdminController();
 

--- a/src/models/admin.js
+++ b/src/models/admin.js
@@ -1,33 +1,38 @@
-const mongoose = require('mongoose');
-const mongodbErrorHandler = require('mongoose-mongodb-errors');
-const bcrypt = require('bcrypt');
-const jwt = require('jsonwebtoken');
-const findOrCreate = require('mongoose-findorcreate');
+const mongoose = require("mongoose");
+const mongodbErrorHandler = require("mongoose-mongodb-errors");
+const bcrypt = require("bcrypt");
+const jwt = require("jsonwebtoken");
+const findOrCreate = require("mongoose-findorcreate");
 // const moment = require('moment');
 const saltRounds = 10;
-const { JWT_EXPIRE, JWT_SECRET, JWT_ADMIN_SECRET, AUTH_API_DB } = require('../utils/config');
+const {
+  JWT_EXPIRE,
+  JWT_SECRET,
+  JWT_ADMIN_SECRET,
+  AUTH_API_DB,
+} = require("../utils/config");
 
 // Modified user model
 const userSchema = new mongoose.Schema({
   username: {
     type: String,
     uniqueCaseInsensitive: true,
-    required: [true, 'Please add a name'],
+    required: [true, "Please add a name"],
   },
   email: {
     type: String,
     uniqueCaseInsensitive: true,
-    required: [true, 'Please enter an email'],
+    required: [true, "Please enter an email"],
   },
   password: {
     type: String,
-    required: [true, 'Please enter a Password'],
+    required: [true, "Please enter a Password"],
     minlength: 8,
     // select: false,
   },
   phone_number: {
     type: String,
-    required: [true, 'Please enter a phone number'],
+    required: [true, "Please enter a phone number"],
     min: 10,
   },
   resetPasswordToken: String,
@@ -36,18 +41,22 @@ const userSchema = new mongoose.Schema({
     type: Date,
     default: Date.now,
   },
+  settings: {
+    type: mongoose.Schema.Types.ObjectId,
+    ref: "Settings",
+  },
 });
 userSchema.plugin(findOrCreate);
 userSchema.plugin(mongodbErrorHandler);
 
 // remove password, _id and return id instead whenever user is retrieved from db
-userSchema.set('toJSON', {
+userSchema.set("toJSON", {
   virtuals: true,
   versionKey: false,
   transform: (document, returnedObject) => {
     delete returnedObject._id;
     delete returnedObject.password;
-  }
+  },
 });
 
 userSchema.methods.matchPasswords = async function (enteredPassword) {
@@ -55,7 +64,7 @@ userSchema.methods.matchPasswords = async function (enteredPassword) {
   return await bcrypt.compare(enteredPassword, this.password);
 };
 
-userSchema.pre('save', function () {
+userSchema.pre("save", function () {
   // Check if password is present and is modified, then hash
   const user = this;
 
@@ -73,7 +82,7 @@ userSchema.methods.generateAPIKEY = function () {
     {
       id: admin.id,
       email: admin.email,
-      DBURI: AUTH_API_DB
+      DBURI: AUTH_API_DB,
     },
     JWT_ADMIN_SECRET
   );
@@ -85,7 +94,7 @@ userSchema.statics.findByToken = function (token, cb) {
   jwt.verify(token, JWT_SECRET, (err, decode) => {
     if (err) {
       return cb(err);
-    };
+    }
     user.findOne({ id: decode, token }, (err, user) => {
       if (err) {
         return cb(err);
@@ -95,4 +104,4 @@ userSchema.statics.findByToken = function (token, cb) {
   });
 };
 
-module.exports = mongoose.model('adminUser', userSchema);
+module.exports = mongoose.model("adminUser", userSchema);

--- a/src/models/settings.js
+++ b/src/models/settings.js
@@ -1,0 +1,66 @@
+const mongoose = require("mongoose");
+const mongodbErrorHandler = require("mongoose-mongodb-errors");
+const findOrCreate = require("mongoose-findorcreate");
+
+// Subschema for the Facebook authentication provider credentials.
+const FacebookAuthProviderCredentialsSchema = new mongoose.Schema({});
+
+// Subschema for the Twitter authentication provider credentials.
+const TwitterAuthProviderCredentialsSchema = new mongoose.Schema({});
+
+// Subschema for the Google authentication provider credentials.
+const GoogleAuthProviderCredentialsSchema = new mongoose.Schema({});
+
+// Subschema for the GitHub authentication provider credentials.
+const GitHubAuthProviderCredentialsSchema = new mongoose.Schema({});
+
+// Settings model
+const settingsSchema = new mongoose.Schema({
+  facebookAuthProvider: {
+    appId: {
+      type: String,
+    },
+    appSecret: {
+      type: String,
+    },
+  },
+  twitterAuthProvider: {
+    key: {
+      type: String,
+    },
+    secret: {
+      type: String,
+    },
+  },
+  githubAuthProvider: {
+    clientId: {
+      type: String,
+    },
+    clientSecret: {
+      type: String,
+    },
+  },
+  googleAuthProvider: {
+    clientId: {
+      type: String,
+    },
+    clientSecret: {
+      type: String,
+    },
+  },
+});
+
+settingsSchema.plugin(findOrCreate);
+settingsSchema.plugin(mongodbErrorHandler);
+
+// remove password, _id and return id instead whenever user is retrieved from db
+settingsSchema.set("toJSON", {
+  virtuals: true,
+  versionKey: false,
+  transform: (document, returnedObject) => {
+    delete returnedObject._id;
+    delete returnedObject.__v;
+  },
+});
+
+module.exports = mongoose.model("Settings", settingsSchema);

--- a/src/models/user.js
+++ b/src/models/user.js
@@ -1,28 +1,27 @@
-const mongoose = require('mongoose');
-const mongodbErrorHandler = require('mongoose-mongodb-errors');
-const bcrypt = require('bcrypt');
-const jwt = require('jsonwebtoken');
-const findOrCreate = require('mongoose-findorcreate');
+const mongoose = require("mongoose");
+const mongodbErrorHandler = require("mongoose-mongodb-errors");
+const bcrypt = require("bcrypt");
+const jwt = require("jsonwebtoken");
+const findOrCreate = require("mongoose-findorcreate");
 const saltRounds = 10;
-const { JWT_EXPIRE, JWT_SECRET } = require('../utils/config');
-
+const { JWT_EXPIRE, JWT_SECRET } = require("../utils/config");
 
 // Modified user model
 const userSchema = new mongoose.Schema({
   username: {
     type: String,
     uniqueCaseInsensitive: true,
-    required: [true, 'Please add a name'],
+    required: [true, "Please add a name"],
   },
   twoFactorAuth: {
     is2FA: {
       type: Boolean,
-      default: false
+      default: false,
     },
     status: {
       type: String,
-      default: null
-    }
+      default: null,
+    },
   },
   failedAttempts: {
     count: {
@@ -36,7 +35,7 @@ const userSchema = new mongoose.Schema({
   email: {
     type: String,
     uniqueCaseInsensitive: true,
-    required: [true, 'Please enter an email'],
+    required: [true, "Please enter an email"],
   },
   password: {
     type: String,
@@ -56,6 +55,22 @@ const userSchema = new mongoose.Schema({
     default: Date.now,
   },
   isEmailVerified: {
+    type: Boolean,
+    default: false,
+  },
+  twitterEnabled: {
+    type: Boolean,
+    default: false,
+  },
+  facebookEnabled: {
+    type: Boolean,
+    default: false,
+  },
+  githubEnabled: {
+    type: Boolean,
+    default: false,
+  },
+  googleEnabled: {
     type: Boolean,
     default: false,
   },
@@ -82,7 +97,7 @@ const userSchema = new mongoose.Schema({
 userSchema.plugin(mongodbErrorHandler);
 userSchema.plugin(findOrCreate);
 // remove password, _id and return id instead whenever user is retrieved from db
-userSchema.set('toJSON', {
+userSchema.set("toJSON", {
   virtuals: true,
   versionKey: false,
   transform: (document, returnedObject) => {
@@ -96,11 +111,11 @@ userSchema.methods.matchPasswords = async function (enteredPassword) {
   return await bcrypt.compare(enteredPassword, this.password);
 };
 
-userSchema.pre('save', function () {
+userSchema.pre("save", function () {
   // Check if password is present and is modified, then hash
   const user = this;
 
-  if (user.password && user.isModified('password')) {
+  if (user.password && user.isModified("password")) {
     user.password = bcrypt.hashSync(user.password, saltRounds);
   }
 });
@@ -118,7 +133,7 @@ userSchema.methods.generateToken = async function () {
 userSchema.statics.findByToken = function (token, cb) {
   let user = this;
 
-  jwt.verify(token, 'secret', (err, decode) => {
+  jwt.verify(token, "secret", (err, decode) => {
     user.findOne({ _id: decode, token: token }, (err, user) => {
       if (err) {
         return cb(err);
@@ -128,4 +143,4 @@ userSchema.statics.findByToken = function (token, cb) {
   });
 };
 
-module.exports = mongoose.model('User', userSchema);
+module.exports = mongoose.model("User", userSchema);

--- a/src/routes/adminAuth.js
+++ b/src/routes/adminAuth.js
@@ -1,16 +1,40 @@
-const adminRouter = require('express').Router();
-const { registerValidation, loginValidation, forgotValidation, resetPasswordValidation } = require('../utils/validation/joiValidation');
-const AdminCtrl = require('../controllers/admin');
+const adminRouter = require("express").Router();
+const {
+  registerValidation,
+  loginValidation,
+  updateSettingsValidation,
+  forgotValidation,
+  resetPasswordValidation,
+} = require("../utils/validation/joiValidation");
+const AdminCtrl = require("../controllers/admin");
 
 module.exports = () => {
-  adminRouter.post('/register', registerValidation(), AdminCtrl.register);
-  adminRouter.post('/getkey', loginValidation(), AdminCtrl.getKey);
-  adminRouter.post('/reset-password', forgotValidation(), AdminCtrl.forgotPassword);
+  adminRouter.post("/register", registerValidation(), AdminCtrl.register);
+  adminRouter.post("/getkey", loginValidation(), AdminCtrl.getKey);
+  adminRouter.post(
+    "/reset-password",
+    forgotValidation(),
+    AdminCtrl.forgotPassword
+  );
+  adminRouter.get("/settings", AdminCtrl.getSettings);
+  adminRouter.patch(
+    "/settings",
+    updateSettingsValidation(),
+    AdminCtrl.updateSettings
+  );
   /* I'll deal with this later */
-  adminRouter.get('/reset-password/:token', (request, response, next) => {
-    response.status(200).send('It\'s cool you\'re here 😁, but you should be using postman to send a PATCH request to change password via this url!');
+  adminRouter.get("/reset-password/:token", (request, response, next) => {
+    response
+      .status(200)
+      .send(
+        "It's cool you're here 😁, but you should be using postman to send a PATCH request to change password via this url!"
+      );
   });
-  adminRouter.patch('/reset-password/:token', resetPasswordValidation(), AdminCtrl.resetPassword);
+  adminRouter.patch(
+    "/reset-password/:token",
+    resetPasswordValidation(),
+    AdminCtrl.resetPassword
+  );
 
   return adminRouter;
 };

--- a/src/services/adminAuth.js
+++ b/src/services/adminAuth.js
@@ -1,25 +1,27 @@
-const mongoose = require('mongoose');
-const Admin = require('../models/admin');
-const CustomError = require('../utils/CustomError');
-const RandomString = require('randomstring');
-const crypto = require('crypto');
-const bcrypt = require('bcrypt');
-const { sendForgotPasswordMail } = require('../EmailFactory/index');
+const mongoose = require("mongoose");
+const Admin = require("../models/admin");
+const Settings = require("../models/settings");
+const CustomError = require("../utils/CustomError");
+const RandomString = require("randomstring");
+const { sendForgotPasswordMail } = require("../EmailFactory/index");
 
-class AdminService{
-  async register(body){    
-    // Adds a new admin to Auth-MicroApi DB   
+class AdminService {
+  async register(body) {
+    // Adds a new admin to Auth-MicroApi DB
     let user = await Admin.findOne({ email: body.email });
     if (user) {
-      throw new CustomError('Email address already in use', 403);
+      throw new CustomError("Email address already in use", 403);
     }
     // const myDB = mongoose.connection.useDb();
-  
+
     // const UserInfo = myDB.model('userInfo', userInfoSchema);
-  
-    user = new Admin(body);
+
+    let settings = new Settings();
+    settings = await settings.save();
+
+    user = new Admin({ ...body, settings: settings._id });
     user = await user.save();
-  
+
     // DON'T DELETE: Admin acc. verification
     // Send a confirmation link to email
     // const mailStatus = await createVerificationLink(user, request);
@@ -30,30 +32,91 @@ class AdminService{
     return data;
   }
 
-  async getKey(body){
+  async getKey(body) {
     // New API KEY for admin
     let user = await Admin.findOne({ email: body.email });
-  
+
     if (!user) {
-      throw new CustomError('Authentication failed, email not found', 401);
+      throw new CustomError("Authentication failed, email not found", 401);
     }
-  
+
     if (!user.matchPasswords(body.password)) {
-      throw new CustomError('Authentication failed, password is incorrect', 401);
+      throw new CustomError(
+        "Authentication failed, password is incorrect",
+        401
+      );
     }
-  
-    let message = 'API_KEY should be set in authorization header as - Bearer <token> - for subsequent user requests';
+
+    let message =
+      "API_KEY should be set in authorization header as - Bearer <token> - for subsequent user requests";
     let data = { API_KEY: user.generateAPIKEY() };
 
     return {
       data: data,
-      message: message
+      message: message,
     };
-
   }
 
-  async forgotPassword(req){
-    
+  async getSettings(body) {
+    // New API KEY for admin
+    let user = await Admin.findOne({
+      email: body.email,
+    }).populate("settings");
+
+    if (!user) {
+      throw new CustomError("Admin with email not found", 404);
+    }
+
+    const data = user;
+    const message = "Settings retrieved successfully";
+
+    return {
+      data: data,
+      message: message,
+    };
+  }
+
+  async updateSettings(body) {
+    // New API KEY for admin
+    let user = await Admin.findOne({ email: body.email });
+
+    if (!user) {
+      throw new CustomError("Admin with email not found", 404);
+    }
+
+    let settings = await Settings.findById(user.settings);
+
+    if (!settings) {
+      throw new CustomError("Settings not found or deleted", 404);
+    }
+
+    // Update settings with the providers provided in the request body.
+    const {
+      facebookAuthProvider,
+      twitterAuthProvider,
+      githubAuthProvider,
+      googleAuthProvider,
+    } = body;
+
+    await Settings.findByIdAndUpdate(settings.id, {
+      $set: {
+        facebookAuthProvider,
+        twitterAuthProvider,
+        githubAuthProvider,
+        googleAuthProvider,
+      },
+    });
+
+    const data = settings;
+    const message = "Settings updated successfully";
+
+    return {
+      data: data,
+      message: message,
+    };
+  }
+
+  async forgotPassword(req) {
     const { email } = req.body;
     // const buffer = crypto.randomBytes(32);
     // const token = buffer.toString();
@@ -61,97 +124,97 @@ class AdminService{
     const expirationTime = Date.now() + 3600000; // 1 hour
     const admin = await Admin.findOneAndUpdate(
       {
-        email
+        email,
       },
       {
         resetPasswordToken: token,
-        resetPasswordExpire: expirationTime
+        resetPasswordExpire: expirationTime,
       },
       {
-        new: true
+        new: true,
       }
     );
-  
+
     if (!admin) {
       throw new CustomError(
         `Sorry an Account with Email: ${email} doesn't exist on this service`,
-        404,
+        404
       );
     }
-  
+
     const resetUrl = `http:\/\/${req.headers.host}\/api\/auth\/admin\/reset-password\/${token}`;
     sendForgotPasswordMail(admin.email, admin.username, resetUrl);
-    
+
     return {
       url: resetUrl,
-      email: admin.email
+      email: admin.email,
     };
-
   } // end forgotPassword
 
-  async resetPassword(req){
+  async resetPassword(req) {
     const { token } = req.params;
     const { password } = req.body;
     const admin = await Admin.findOneAndUpdate(
       {
         resetPasswordToken: token,
         resetPasswordExpire: {
-          $gt: Date.now()
-        }
+          $gt: Date.now(),
+        },
       },
       {
         password,
         resetPasswordToken: null,
-        resetPasswordExpire: null
+        resetPasswordExpire: null,
       },
       {
-        new: true
+        new: true,
       }
     );
     if (!admin) {
       throw new CustomError(
-        'Password reset token is invalid or has expired.',
-        422,
+        "Password reset token is invalid or has expired.",
+        422
       );
     }
 
     return {
-      status: 'success'
+      status: "success",
     };
-
   } // end resetPassword
 
-  async deactivateUser(req){
+  async deactivateUser(req) {
     const userId = req.params.userId;
-  
-    if(!mongoose.Types.ObjectId.isValid(userId)){
+
+    if (!mongoose.Types.ObjectId.isValid(userId)) {
       return {
-        status: 'fail',
+        status: "fail",
         code: 400,
-        message: 'Invalid user id'
+        message: "Invalid user id",
       };
     }
-  
+
     try {
-      const result = await User.updateOne({_id: userId},{$set: {active : 0}});
-      if(!result){
+      const result = await User.updateOne(
+        { _id: userId },
+        { $set: { active: 0 } }
+      );
+      if (!result) {
         return {
-          status: 'fail',
+          status: "fail",
           code: 400,
-          message: 'User not found.'
+          message: "User not found.",
         };
       }
       return {
-        status: 'success',
+        status: "success",
         code: 200,
-        message: 'User deactivated'
+        message: "User deactivated",
       };
-    }
-    catch(err){
+    } catch (err) {
       return {
-        status: 'error',
+        status: "error",
         code: 500,
-        message: 'Something went wrong.'
+        message: "Something went wrong.",
       };
     }
   }

--- a/src/utils/CustomError.js
+++ b/src/utils/CustomError.js
@@ -6,6 +6,4 @@ class CustomError extends Error {
   }
 }
 
-module.exports = {
-  CustomError
-};
+module.exports = CustomError;

--- a/src/utils/validation/joiValidation.js
+++ b/src/utils/validation/joiValidation.js
@@ -1,5 +1,4 @@
-const Joi = require('@hapi/joi');
-
+const Joi = require("@hapi/joi");
 
 const validator = async (schema, toValidate, res, next) => {
   // This middleware will validate client's request body
@@ -19,7 +18,10 @@ exports.registerValidation = () => (req, res, next) => {
       .trim()
       .required(),
     password: Joi.string().min(8).max(20).required(),
-    phone_number: Joi.string().min(10).max(11).pattern(/^[0-9]+$/),
+    phone_number: Joi.string()
+      .min(10)
+      .max(11)
+      .pattern(/^[0-9]+$/),
   });
   return validator(schema, req.body, res, next);
 };
@@ -34,6 +36,35 @@ exports.loginValidation = () => (req, res, next) => {
       .trim()
       .required(),
     password: Joi.string().min(8).max(20).required(),
+  });
+  return validator(schema, req.body, res, next);
+};
+
+exports.updateSettingsValidation = () => (req, res, next) => {
+  const schema = Joi.object().keys({
+    email: Joi.string()
+      .email({
+        minDomainSegments: 2,
+        tlds: { allow: true },
+      })
+      .trim()
+      .required(),
+    facebookAuthProvider: Joi.object().keys({
+      appId: Joi.string().required(),
+      appSecret: Joi.string().required(),
+    }),
+    twitterAuthProvider: Joi.object().keys({
+      key: Joi.string().required(),
+      secret: Joi.string().required(),
+    }),
+    githubAuthProvider: Joi.object().keys({
+      clientId: Joi.string().required(),
+      clientSecret: Joi.string().required(),
+    }),
+    googleAuthProvider: Joi.object().keys({
+      clientId: Joi.string().required(),
+      clientSecret: Joi.string().required(),
+    }),
   });
   return validator(schema, req.body, res, next);
 };
@@ -54,7 +85,7 @@ exports.forgotValidation = () => (req, res, next) => {
 exports.resetPasswordValidation = () => (req, res, next) => {
   const schema = Joi.object().keys({
     password: Joi.string().min(8).max(20).required(),
-    password_confirmation: Joi.any().valid(Joi.ref('password')).required()
+    password_confirmation: Joi.any().valid(Joi.ref("password")).required(),
   });
   return validator(schema, req.body, res, next);
 };


### PR DESCRIPTION
**What does this PR do?**

Fixes #497 

**description of Task to be completed?**

- [x] Create Settings model to store the credentials from authentication providers (available options are Facebook, Twitter, Google, and Github).
- [x] Update the Admin model to store a reference to a settings document.
- [x] Add endpoints to get and update settings: GET `/api/admin/settings` and PATCH `/api/admin/settings`.
- [x] Add validation middleware for added admin settings endpoints.
- [x] Add fields in User model to keep track of enabled authentication providers (e.g. `{ googleEnabled: true }`).
- [ ] Update social sign in/up endpoints to get credentials from settings model, after checking in the user model if its an enabled authentication provider, when processing requests.

**How should this be manually tested?**

- In your terminal, run `npm run dev`.
- In postman, register an admin - POST /api/admin/register.
- In postman, get default settings - GET /api/admin/settings.
- In postman, update settings - PATCH /api/admin/settings.

**Any background context you want to provide?**
