### PR TITLE
feat: add configurable social sign in/up

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -1,36 +1,32 @@
-require('express-async-errors');
-require('dotenv').config();
-const express = require('express');
+require("express-async-errors");
+require("dotenv").config();
+const express = require("express");
 const app = express();
-const cors = require('cors');
-// const passport = require('passport');
-const cookieParser = require('cookie-parser');
-const userRouter = require('./routes/auth');
-const adminRouter = require('./routes/adminAuth');
-const fbRouter = require('./routes/fbauth');
-const twitterRouter = require('./routes/twitterAuth');
-const gitRouter = require('./routes/gitauth');
-const emailVerificationRouter = require('./routes/EmailVerification');
-// const resetPasswordRouter = require('./routes/resetPassword');
-const { connectDB } = require('./controllers/db');
+const cors = require("cors");
+const cookieParser = require("cookie-parser");
+const userRouter = require("./routes/auth");
+const adminRouter = require("./routes/adminAuth");
+const fbRouter = require("./routes/fbauth");
+const twitterRouter = require("./routes/twitterAuth");
+const gitRouter = require("./routes/gitauth");
+const docRouter = require("./routes/documentation");
+const emailVerificationRouter = require("./routes/EmailVerification");
+const { connectDB } = require("./controllers/db");
 const {
   authorizeUser,
   errorHandler,
   unknownRoutes,
-} = require('./middlewares/middleware');
-const swaggerUi = require('swagger-ui-express');
-const openApiDocumentation = require('./swagger/openApiDocumentation');
-// const adminFunctionRouter = require('./routes/admin');
-const googleLoginRouter = require('./routes/googleLogin');
-require('./config/passport/twitterStrategy');
-require('./config/passport/githubStrategy');
-require('./config/passport/googleStrategy');
-require('./config/passport/facebookStrategy');
+} = require("./middlewares/middleware");
+const googleLoginRouter = require("./routes/googleLogin");
+require("./config/passport/twitterStrategy");
+require("./config/passport/githubStrategy");
+require("./config/passport/googleStrategy");
+require("./config/passport/facebookStrategy");
 
-require('dotenv').config();
+require("dotenv").config();
 
 connectDB();
-const SessionMgt = require('./services/SessionManagement');
+const SessionMgt = require("./services/SessionManagement");
 
 app.use(cors());
 app.use(cookieParser());
@@ -46,20 +42,17 @@ app.use(
 SessionMgt.config(app);
 
 // auth routes
-app.use('/api/admin', adminRouter());
-app.use('/api/user/email-verification', emailVerificationRouter());
-app.use('/api/user/password', userRouter());
-app.use('/api/user', authorizeUser, userRouter());
-app.use('/api/facebook', fbRouter);
-app.use('/api/twitter', twitterRouter);
-app.use('/api/github', gitRouter);
-app.use('/api/google', googleLoginRouter);
+app.use("/api/admin", adminRouter());
+app.use("/api/user/email-verification", emailVerificationRouter());
+app.use("/api/user/password", userRouter());
+app.use("/api/user", authorizeUser, userRouter());
+app.use("/api/facebook", fbRouter);
+app.use("/api/twitter", twitterRouter);
+app.use("/api/github", gitRouter);
+app.use("/api/google", googleLoginRouter);
 
-// DON'T DELETE: Admin acc. verification
-
-// app.use('/api/admin/auth/email', emailVerificationRouter());
-app.use('/api/doc', swaggerUi.serve, swaggerUi.setup(openApiDocumentation));
-// app.use('/swagger', swaggerUi.serve, swaggerUi.setup(swaggerDocs));
+// documentation routes
+app.use("/", docRouter);
 
 app.use(unknownRoutes);
 app.use(errorHandler);

--- a/src/config/passport/facebookStrategy.js
+++ b/src/config/passport/facebookStrategy.js
@@ -4,7 +4,9 @@ const User = require("../../models/user");
 const SessionManagement = require("../../services/SessionManagement");
 
 /**
- * Sign in with Facebook.
+ * Returns a new Facebook Strategy using the provided credentials.
+ *
+ * @param {object} provider - The configuration object containing credentials for Facebook.
  */
 const createFacebookStrategy = (provider) => {
   let clientID = "noID";
@@ -27,6 +29,14 @@ const createFacebookStrategy = (provider) => {
   );
 };
 
+/**
+ *
+ * @param {*} req
+ * @param {*} accessToken
+ * @param {*} refreshToken
+ * @param {*} profile
+ * @param {*} done
+ */
 const callback = (req, accessToken, refreshToken, profile, done) => {
   if (req.user) {
     User.findOne({ facebook: profile.id }, (err, existingUser) => {

--- a/src/config/passport/facebookStrategy.js
+++ b/src/config/passport/facebookStrategy.js
@@ -1,16 +1,24 @@
 const passport = require("passport");
-const { Strategy: FacebookStrategy } = require("passport-facebook");
+const FacebookStrategy = require("passport-facebook").Strategy;
 const User = require("../../models/user");
 const SessionManagement = require("../../services/SessionManagement");
 
 /**
  * Sign in with Facebook.
  */
-const createFacebookStrategy = (appID, appSecret) => {
+const createFacebookStrategy = (provider) => {
+  let clientID = "noID";
+  let clientSecret = "noSecret";
+
+  if (provider && provider.appID) {
+    clientID = provider.appID;
+    clientSecret = provider.appSecret;
+  }
+
   return new FacebookStrategy(
     {
-      clientID: appID || process.env.FACEBOOK_APP_ID,
-      clientSecret: appSecret || process.env.FACEBOOK_APP_SECRET,
+      clientID: clientID,
+      clientSecret: clientSecret,
       callbackURL: `${process.env.HOST}/api/facebook/callback`,
       profileFields: ["name", "email", "link", "locale", "timezone", "gender"],
       passReqToCallback: true,
@@ -20,8 +28,6 @@ const createFacebookStrategy = (appID, appSecret) => {
 };
 
 const callback = (req, accessToken, refreshToken, profile, done) => {
-  console.log(profile);
-
   if (req.user) {
     User.findOne({ facebook: profile.id }, (err, existingUser) => {
       if (err) {

--- a/src/config/passport/facebookStrategy.js
+++ b/src/config/passport/facebookStrategy.js
@@ -1,83 +1,98 @@
-const passport = require('passport');
-const { Strategy: FacebookStrategy } = require('passport-facebook');
+const passport = require("passport");
+const { Strategy: FacebookStrategy } = require("passport-facebook");
 const User = require("../../models/user");
 const SessionManagement = require("../../services/SessionManagement");
 
-
-
-passport.serializeUser((user, done) => {
-    done(null, user.id);
-  });
-  
-  passport.deserializeUser((id, done) => {
-    User.findById(id, (err, user) => {
-      done(err, user);
-    });
-  });
-  
-
-
-  
 /**
  * Sign in with Facebook.
  */
-passport.use(new FacebookStrategy({
-    clientID: process.env.FACEBOOK_APP_ID,
-    clientSecret: process.env.FACEBOOK_APP_SECRET,
-    callbackURL: `${process.env.HOST}/api/facebook/callback`,
-    profileFields: ['name', 'email', 'link', 'locale', 'timezone', 'gender'],
-    passReqToCallback: true
-  }, (req, accessToken, refreshToken, profile, done) => {
-      console.log(profile);
+const createFacebookStrategy = (appID, appSecret) => {
+  return new FacebookStrategy(
+    {
+      clientID: appID || process.env.FACEBOOK_APP_ID,
+      clientSecret: appSecret || process.env.FACEBOOK_APP_SECRET,
+      callbackURL: `${process.env.HOST}/api/facebook/callback`,
+      profileFields: ["name", "email", "link", "locale", "timezone", "gender"],
+      passReqToCallback: true,
+    },
+    callback
+  );
+};
 
-    if (req.user) {
-      User.findOne({ facebook: profile.id }, (err, existingUser) => {
-        if (err) { return done(err); }
-        if (existingUser) {
-            SessionManagement.login(req, existingUser);
+const callback = (req, accessToken, refreshToken, profile, done) => {
+  console.log(profile);
 
-          done(err,existingUser);
-        } else {
-          User.findById(req.user.id, (err, user) => {
-            if (err) { return done(err); }
-            user.facebook = profile.id;
-            user.email = profile._json.email;
-            user.username = `${profile.name.givenName} ${profile.name.familyName}`;
-            user.tokens.push({ kind: 'facebook', accessToken });
-            user.profile.name = user.profile.name || `${profile.name.givenName} ${profile.name.familyName}`;
-            user.profile.gender = user.profile.gender || profile._json.gender;
-            user.profile.picture = user.profile.picture || `https://graph.facebook.com/${profile.id}/picture?type=large`;
-            user.save((err) => {
-             SessionManagement.login(req, user);
+  if (req.user) {
+    User.findOne({ facebook: profile.id }, (err, existingUser) => {
+      if (err) {
+        return done(err);
+      }
+      if (existingUser) {
+        SessionManagement.login(req, existingUser);
 
-              done(err, user);
-            });
+        done(err, existingUser);
+      } else {
+        User.findById(req.user.id, (err, user) => {
+          if (err) {
+            return done(err);
+          }
+          user.facebook = profile.id;
+          user.email = profile._json.email;
+          user.username = `${profile.name.givenName} ${profile.name.familyName}`;
+          user.tokens.push({ kind: "facebook", accessToken });
+          user.profile.name =
+            user.profile.name ||
+            `${profile.name.givenName} ${profile.name.familyName}`;
+          user.profile.gender = user.profile.gender || profile._json.gender;
+          user.profile.picture =
+            user.profile.picture ||
+            `https://graph.facebook.com/${profile.id}/picture?type=large`;
+          user.save((err) => {
+            SessionManagement.login(req, user);
+
+            done(err, user);
           });
-        }
-      });
-    } else {
-      User.findOne({ facebook: profile.id }, (err, existingUser) => {
-        if (err) { return done(err); }
-        if (existingUser) {
-          SessionManagement.login(req, existingUser);
+        });
+      }
+    });
+  } else {
+    User.findOne({ facebook: profile.id }, (err, existingUser) => {
+      if (err) {
+        return done(err);
+      }
+      if (existingUser) {
+        SessionManagement.login(req, existingUser);
 
-          return done(null, existingUser);
-        }
-            const user = new User();
-            user.email = profile._json.email;
-            user.facebook = profile.id;
-            user.username = `${profile.name.givenName} ${profile.name.familyName}`;
+        return done(null, existingUser);
+      }
+      const user = new User();
+      user.email = profile._json.email;
+      user.facebook = profile.id;
+      user.username = `${profile.name.givenName} ${profile.name.familyName}`;
 
-            user.tokens.push({ kind: 'facebook', accessToken });
-            user.profile.name = `${profile.name.givenName} ${profile.name.familyName}`;
-            user.profile.gender = profile._json.gender;
-            user.profile.picture = `https://graph.facebook.com/${profile.id}/picture?type=large`;
-            user.profile.location = (profile._json.location) ? profile._json.location.name : '';
-            user.save((err) => {
-              SessionManagement.login(req, existingUser);
-              done(err, user);
-            });
-          
+      user.tokens.push({ kind: "facebook", accessToken });
+      user.profile.name = `${profile.name.givenName} ${profile.name.familyName}`;
+      user.profile.gender = profile._json.gender;
+      user.profile.picture = `https://graph.facebook.com/${profile.id}/picture?type=large`;
+      user.profile.location = profile._json.location
+        ? profile._json.location.name
+        : "";
+      user.save((err) => {
+        SessionManagement.login(req, existingUser);
+        done(err, user);
       });
-    }
-  }));
+    });
+  }
+};
+
+passport.serializeUser((user, done) => {
+  done(null, user.id);
+});
+
+passport.deserializeUser((id, done) => {
+  User.findById(id, (err, user) => {
+    done(err, user);
+  });
+});
+
+module.exports = createFacebookStrategy;

--- a/src/config/passport/githubStrategy.js
+++ b/src/config/passport/githubStrategy.js
@@ -4,6 +4,59 @@ const _ = require("lodash");
 const passport = require("passport");
 const SessionManagement = require("../../services/SessionManagement");
 
+/**
+ * Sign in with GitHub.
+ */
+const createGithubStrategy = (clientID, clientSecret) => {
+  return new GitHubStrategy(
+    {
+      clientID: clientID || process.env.GITHUB_CLIENT_ID,
+      clientSecret: clientSecret || process.env.GITHUB_CLIENT_SECRET,
+      callbackURL: `${process.env.HOST}/api/github/callback`,
+      passReqToCallback: true,
+      scope: ["user:email"],
+    },
+    callback
+  );
+};
+
+const callback = (req, accessToken, refreshToken, profile, done) => {
+  User.findOne({ twitter: profile.id }, (err, existingUser) => {
+    if (err) {
+      return done(err);
+    }
+    if (existingUser) {
+      SessionManagement.login(req, existingUser);
+      return done(null, existingUser);
+    }
+    const user = new User();
+    // Twitter will not provide an email address.  Period.
+    // But a person’s twitter username is guaranteed to be unique
+    // so we can "fake" a twitter email address as follows:
+    user.email = _.get(
+      _.orderBy(profile.emails, ["primary", "verified"], ["desc", "desc"]),
+      [0, "value"],
+      null
+    );
+
+    user.github = profile.id;
+    user.tokens.push({ kind: "github", accessToken });
+    user.profile.name = profile.displayName;
+    user.username = profile.displayName;
+    user.profile.name = user.profile.name || profile.displayName;
+    user.profile.picture = user.profile.picture || profile._json.avatar_url;
+    user.profile.location = user.profile.location || profile._json.location;
+    user.profile.website = user.profile.website || profile._json.blog;
+
+    user.save((err) => {
+      SessionManagement.login(req, new Object(user));
+
+      return done(err, user);
+    });
+  });
+};
+
+// use static serialize and deserialize of model for passport session support
 passport.serializeUser((user, done) => {
   done(null, user.id);
 });
@@ -14,54 +67,4 @@ passport.deserializeUser((id, done) => {
   });
 });
 
-/**
- * Sign in with GitHub.
- */
-
-passport.use(
-  new GitHubStrategy(
-    {
-      clientID: process.env.GITHUB_CLIENT_ID,
-      clientSecret: process.env.GITHUB_CLIENT_SECRET,
-      callbackURL: `${process.env.HOST}/api/github/callback`,
-      passReqToCallback: true,
-      scope: ["user:email"],
-    },
-    (req, accessToken, refreshToken, profile, done) => {
-      console.log(req.session);
-      User.findOne({ twitter: profile.id }, (err, existingUser) => {
-        if (err) {
-          return done(err);
-        }
-        if (existingUser) {
-          SessionManagement.login(req, existingUser);
-          return done(null, existingUser);
-        }
-        const user = new User();
-        // Twitter will not provide an email address.  Period.
-        // But a person’s twitter username is guaranteed to be unique
-        // so we can "fake" a twitter email address as follows:
-        user.email = _.get(
-          _.orderBy(profile.emails, ["primary", "verified"], ["desc", "desc"]),
-          [0, "value"],
-          null
-        );
-
-        user.github = profile.id;
-        user.tokens.push({ kind: "github", accessToken });
-        user.profile.name = profile.displayName;
-        user.username = profile.displayName;
-        user.profile.name = user.profile.name || profile.displayName;
-        user.profile.picture = user.profile.picture || profile._json.avatar_url;
-        user.profile.location = user.profile.location || profile._json.location;
-        user.profile.website = user.profile.website || profile._json.blog;
-
-        user.save((err) => {
-          SessionManagement.login(req, new Object(user));
-
-          return done(err, user);
-        });
-      });
-    }
-  )
-);
+module.exports = createGithubStrategy;

--- a/src/config/passport/githubStrategy.js
+++ b/src/config/passport/githubStrategy.js
@@ -1,4 +1,4 @@
-const { Strategy: GitHubStrategy } = require("passport-github2");
+const GitHubStrategy = require("passport-github2").Strategy;
 const User = require("../../models/user");
 const _ = require("lodash");
 const passport = require("passport");
@@ -7,11 +7,19 @@ const SessionManagement = require("../../services/SessionManagement");
 /**
  * Sign in with GitHub.
  */
-const createGithubStrategy = (clientID, clientSecret) => {
+const createGithubStrategy = (provider) => {
+  let clientID = "noID";
+  let clientSecret = "noSecret";
+
+  if (provider && provider.clientID) {
+    clientID = provider.clientID;
+    clientSecret = provider.clientSecret;
+  }
+
   return new GitHubStrategy(
     {
-      clientID: clientID || process.env.GITHUB_CLIENT_ID,
-      clientSecret: clientSecret || process.env.GITHUB_CLIENT_SECRET,
+      clientID,
+      clientSecret,
       callbackURL: `${process.env.HOST}/api/github/callback`,
       passReqToCallback: true,
       scope: ["user:email"],

--- a/src/config/passport/googleStrategy.js
+++ b/src/config/passport/googleStrategy.js
@@ -1,48 +1,51 @@
-const passport = require('passport');
-const GoogleUser = require('../../models/googleUser');
-const GoogleStrategy = require('passport-google-oauth').OAuth2Strategy;
+const passport = require("passport");
+const GoogleUser = require("../../models/googleUser");
+const GoogleStrategy = require("passport-google-oauth").OAuth2Strategy;
 
-
-passport.use(
-  new GoogleStrategy(
+const createGoogleStrategy = (clientID, clientSecret) => {
+  return new GoogleStrategy(
     {
-      clientID: process.env.GOOGLE_CLIENT_ID,
-      clientSecret: process.env.GOOGLE_CLIENT_SECRET,
+      clientID: clientID || process.env.GOOGLE_CLIENT_ID,
+      clientSecret: clientSecret || process.env.GITHUB_CLIENT_SECRET,
       callbackURL: `${process.env.HOST}/api/auth/google/callback`,
     },
-    (accessToken, refreshToken, profile, done) => {
-      GoogleUser.findOne({ email: profile.emails[0].value }, (err, user) => {
-        if (err) {
-          return done(err);
-        }
-        // Check if the user is available
-        if (!user) {
-          let newUser = new GoogleUser({
-            googleId: profile.id,
-            username: profile.displayName.trim(),
-            firstname: profile.name.givenName,
-            lastname: profile.name.familyName,
-            email: profile.emails[0].value,
-            isVerified: profile.emails[0].verified,
-          });
-  
-          newUser.save((err) => {
-            if (err) {
-              console.log(err);
-            }
-            console.log('===New=Google=Profile===');
-            return done(err, newUser);
-          });
-        } else {
-          console.log('===Existing=Google=Profile===');
-          // console.log(user);
-          return done(err, user);
-        }
-      });
+    callback
+  );
+};
+
+const callback = (accessToken, refreshToken, profile, done) => {
+  GoogleUser.findOne({ email: profile.emails[0].value }, (err, user) => {
+    if (err) {
+      return done(err);
     }
-  )
-);
+    // Check if the user is available
+    if (!user) {
+      let newUser = new GoogleUser({
+        googleId: profile.id,
+        username: profile.displayName.trim(),
+        firstname: profile.name.givenName,
+        lastname: profile.name.familyName,
+        email: profile.emails[0].value,
+        isVerified: profile.emails[0].verified,
+      });
+
+      newUser.save((err) => {
+        if (err) {
+          console.log(err);
+        }
+        console.log("===New=Google=Profile===");
+        return done(err, newUser);
+      });
+    } else {
+      console.log("===Existing=Google=Profile===");
+      // console.log(user);
+      return done(err, user);
+    }
+  });
+};
+
 // Persist the user
 passport.serializeUser(GoogleUser.serializeUser());
 passport.deserializeUser(GoogleUser.deserializeUser());
-  
+
+module.exports = createGoogleStrategy;

--- a/src/config/passport/googleStrategy.js
+++ b/src/config/passport/googleStrategy.js
@@ -7,7 +7,7 @@ const createGoogleStrategy = (clientID, clientSecret) => {
     {
       clientID: clientID || process.env.GOOGLE_CLIENT_ID,
       clientSecret: clientSecret || process.env.GITHUB_CLIENT_SECRET,
-      callbackURL: `${process.env.HOST}/api/auth/google/callback`,
+      callbackURL: `${process.env.HOST}/api/google/callback`,
     },
     callback
   );

--- a/src/config/passport/googleStrategy.js
+++ b/src/config/passport/googleStrategy.js
@@ -2,11 +2,19 @@ const passport = require("passport");
 const GoogleUser = require("../../models/googleUser");
 const GoogleStrategy = require("passport-google-oauth").OAuth2Strategy;
 
-const createGoogleStrategy = (clientID, clientSecret) => {
+const createGoogleStrategy = (provider) => {
+  let clientID = "noID";
+  let clientSecret = "noSecret";
+
+  if (provider && provider.clientID) {
+    clientID = provider.clientID;
+    clientSecret = provider.clientSecret;
+  }
+
   return new GoogleStrategy(
     {
-      clientID: clientID || process.env.GOOGLE_CLIENT_ID,
-      clientSecret: clientSecret || process.env.GITHUB_CLIENT_SECRET,
+      clientID,
+      clientSecret,
       callbackURL: `${process.env.HOST}/api/google/callback`,
     },
     callback

--- a/src/config/passport/twitterStrategy.js
+++ b/src/config/passport/twitterStrategy.js
@@ -1,17 +1,25 @@
 const passport = require("passport");
 const refresh = require("passport-oauth2-refresh");
-const { Strategy: TwitterStrategy } = require("passport-twitter");
+const TwitterStrategy = require("passport-twitter").Strategy;
 const SessionManagement = require("../../services/SessionManagement");
 const User = require("../../models/user");
 
 /**
  * Sign in with Twitter.
  */
-const createTwitterStrategy = (key, secret) => {
+const createTwitterStrategy = (provider) => {
+  let consumerKey = "noKey";
+  let consumerSecret = "noSecret";
+
+  if (provider && provider.key) {
+    consumerKey = provider.key;
+    consumerSecret = provider.secret;
+  }
+
   return new TwitterStrategy(
     {
-      consumerKey: key || process.env.TWITTER_KEY,
-      consumerSecret: secret || process.env.TWITTER_SECRET,
+      consumerKey,
+      consumerSecret,
       callbackURL: `${process.env.HOST}/api/twitter/callback`,
       passReqToCallback: true,
     },
@@ -51,7 +59,6 @@ const callback = (req, accessToken, tokenSecret, profile, done) => {
   //     }
   //   });
   // } else {
-  console.log(req.session);
   User.findOne({ twitter: profile.id }, (err, existingUser) => {
     if (err) {
       return done(err);

--- a/src/controllers/admin.js
+++ b/src/controllers/admin.js
@@ -1,52 +1,59 @@
 /**=================================================================
- * ====   TITLE::     ADDING ADMIN FORGOT AND RESET PASSWORD    ====  
+ * ====   TITLE::     ADDING ADMIN FORGOT AND RESET PASSWORD    ====
  * ====   AUTHOR:: jimoh19 <jemohkunle2007@gmail.com>           ====
  * ====   DATE::            30TH JUNE 2020                      ====
  * =================================================================
  */
 
-const CustomResponse = require('../utils/response');
-const AdminSrv = require('../services/adminAuth');
+const CustomResponse = require("../utils/response");
+const AdminSrv = require("../services/adminAuth");
 
-class AdminController{
-
+class AdminController {
   async register(request, response) {
-  
     const data = await AdminSrv.register(request.body);
-    return response.status(201).json(CustomResponse('Registration successful', data));
-
+    return response
+      .status(201)
+      .json(CustomResponse("Registration successful", data));
   } //end register
 
-  async getKey(request, response){
-  
+  async getKey(request, response) {
     const data = await AdminSrv.getKey(request.body);
     return response.status(200).json(CustomResponse(data.message, data.data));
-
   } //end getKey
 
-  async forgotPassword(request, response){
+  async getSettings(request, response) {
+    const data = await AdminSrv.getSettings(request.body);
+    return response.status(200).json(CustomResponse(data.message, data.data));
+  } //end getSettings
 
+  async updateSettings(request, response) {
+    const data = await AdminSrv.updateSettings(request.body);
+    return response.status(200).json(CustomResponse(data.message, data.data));
+  } //end getSettings
+
+  async forgotPassword(request, response) {
     const data = await AdminSrv.forgotPassword(request);
-    return response.status(200).json(CustomResponse(`A password reset link has been sent to ${data.email}`));
-
+    return response
+      .status(200)
+      .json(
+        CustomResponse(`A password reset link has been sent to ${data.email}`)
+      );
   } //end forgotPassword
 
-  async resetPassword(request, response){
-    
+  async resetPassword(request, response) {
     const data = await AdminSrv.resetPassword(request);
-    return response.status(200).json(CustomResponse('Password updated successfully. You may login'));
-
+    return response
+      .status(200)
+      .json(CustomResponse("Password updated successfully. You may login"));
   } //end resetPassword
 
-  async deactivateUser(req,res){
-
+  async deactivateUser(req, res) {
     const data = await AdminSrv.deactivateUser(req);
-    res.status(data.code).send(CustomResponse('User has been successfully deactivated', data));
-
-  } //end deactivateUser  
-
+    res
+      .status(data.code)
+      .send(CustomResponse("User has been successfully deactivated", data));
+  } //end deactivateUser
 } //end class
-
 
 module.exports = new AdminController();
 

--- a/src/controllers/admin.js
+++ b/src/controllers/admin.js
@@ -22,12 +22,12 @@ class AdminController {
   } //end getKey
 
   async getSettings(request, response) {
-    const data = await AdminSrv.getSettings(request.body);
+    const data = await AdminSrv.getSettings(request);
     return response.status(200).json(CustomResponse(data.message, data.data));
   } //end getSettings
 
   async updateSettings(request, response) {
-    const data = await AdminSrv.updateSettings(request.body);
+    const data = await AdminSrv.updateSettings(request);
     return response.status(200).json(CustomResponse(data.message, data.data));
   } //end getSettings
 

--- a/src/controllers/auth.js
+++ b/src/controllers/auth.js
@@ -5,69 +5,75 @@
  * =================================================================
  */
 
-
-const UserService = require('../services/auth');
-const CustomResponse = require('../utils/response');
-const { CustomError } = require('../utils/CustomError');
-
+const UserService = require("../services/auth");
+const CustomResponse = require("../utils/response");
+const { CustomError } = require("../utils/CustomError");
 
 class UserController {
-
-  async register (req, res) {
-  
+  async register(req, res) {
     const data = await UserService.register(req);
 
     res.status(data.code).json(CustomResponse(data.message, data.user));
   }
 
   async login(req, res) {
-
     const data = await UserService.login(req);
 
-    res.status(200).json(CustomResponse(data ? 'Login successful' : 'Something Wrong/Too many request to Twilio API', data));
+    res
+      .status(200)
+      .json(
+        CustomResponse(
+          data
+            ? "Login successful"
+            : "Something Wrong/Too many request to Twilio API",
+          data
+        )
+      );
   }
 
   async otpVerify(req, res) {
-
     const data = await UserService.otpVerify(req);
 
-    res.status(200).json(CustomResponse('verification data', data));
+    res.status(200).json(CustomResponse("verification data", data));
   }
 
   async enable2FA(req, res) {
-
     const data = await UserService.enable2FA(req);
 
     res.status(200).json(CustomResponse(data));
   }
 
   async activeUser(req, res) {
-
     const data = await UserService.activeUser(req);
 
-    res.status(200).json(CustomResponse('successfully found', data));
+    res.status(200).json(CustomResponse("successfully found", data));
+  }
+
+  async updateAuthProviders(req, res) {
+    const data = await UserService.updateAuthProviders(req);
+
+    res.status(200).json(CustomResponse("successfully updated", data));
   }
 
   async forgotPassword(req, res) {
-    
     const data = await UserService.forgotPassword(req);
 
     res
       .status(200)
       .json(
-        CustomResponse(`A password reset link has been sent to ${data.user.email}`)
+        CustomResponse(
+          `A password reset link has been sent to ${data.user.email}`
+        )
       );
   }
 
   async resetPassword(req, res) {
-
     await UserService.resetPassword(req);
 
     res
       .status(200)
-      .json(CustomResponse('Password updated successfully. You may login'));
+      .json(CustomResponse("Password updated successfully. You may login"));
   }
-
 } //end class UserController
 
 module.exports = new UserController();

--- a/src/middlewares/middleware.js
+++ b/src/middlewares/middleware.js
@@ -1,20 +1,22 @@
-const User = require('../models/user');
-const jwt = require('jsonwebtoken');
-const { JWT_ADMIN_SECRET } = require('../utils/config');
-const CustomResponse = require('../utils/response');
-
+const Admin = require("../models/admin");
+const User = require("../models/user");
+const jwt = require("jsonwebtoken");
+const { JWT_ADMIN_SECRET } = require("../utils/config");
+const CustomResponse = require("../utils/response");
+const { CustomError } = require("../utils/CustomError");
 
 const auth = async (request, response, next) => {
-
   let userId = request.sessions.user;
 
   User.findByToken(userId, (err, user) => {
-    if (err) { throw err; }
+    if (err) {
+      throw err;
+    }
     if (!user) {
       return response.json({
         isAuth: false,
         error: true,
-        msg: 'UnAuthorised/Invalid user'
+        msg: "UnAuthorised/Invalid user",
       });
     }
     request.user = user;
@@ -25,58 +27,149 @@ const auth = async (request, response, next) => {
 const authorizeUser = (request, response, next) => {
   // This middleware authorizes users by checking if valid API_KEY is sent with the request
 
-  const authorization = request.get('authorization');
-  if (authorization && authorization.toLowerCase().startsWith('bearer ')) {
+  const authorization = request.get("authorization");
+  if (authorization && authorization.toLowerCase().startsWith("bearer ")) {
     const token = authorization.substring(7);
     const decodedUser = jwt.verify(token, JWT_ADMIN_SECRET);
 
     if (!decodedUser.id) {
-      return response.status(403).json({ error: 'Invalid API_KEY' });
+      return response.status(403).json({ error: "Invalid API_KEY" });
     }
     // TODO: link users using admin access token, use kaseem's auth middleware
     // TODO: if user has unverified email refer them to email verificaton; use sessions maybe
     request.admin = decodedUser;
   } else {
-    return response.status(401).send('Access denied. No token provided.');
+    return response.status(401).send("Access denied. No token provided.");
   }
 
   next();
 };
 
+const TWITTER_PROVIDER = "Twitter";
+const FACEBOOK_PROVIDER = "Facebook";
+const GITHUB_PROVIDER = "GitHub";
+const GOOGLE_PROVIDER = "Google";
+
+const twitterAuthProvider = (req, res, next) =>
+  authProvider(TWITTER_PROVIDER)(req, res, next);
+const facebookAuthProvider = (req, res, next) =>
+  authProvider(FACEBOOK_PROVIDER)(req, res, next);
+const githubAuthProvider = (req, res, next) =>
+  authProvider(GITHUB_PROVIDER)(req, res, next);
+const googleAuthProvider = (req, res, next) =>
+  authProvider(GOOGLE_PROVIDER)(req, res, next);
+
+const authProvider = (providerType) => {
+  return async (req, res, next) => {
+    const admin = await Admin.findById(req.admin.id).populate("settings");
+
+    let provider;
+    let isProviderEnabled;
+    const message = `${providerType} authentication is not authorized for this account.`;
+
+    switch (providerType) {
+      case TWITTER_PROVIDER:
+        provider = admin.settings.twitterAuthProvider;
+        isProviderEnabled = provider && provider.key;
+        break;
+      case FACEBOOK_PROVIDER:
+        provider = admin.settings.facebookAuthProvider;
+        isProviderEnabled = provider && provider.appID;
+        break;
+      case GITHUB_PROVIDER:
+        provider = admin.settings.githubAuthProvider;
+        isProviderEnabled = provider && provider.clientID;
+        break;
+      case GOOGLE_PROVIDER:
+        provider = admin.settings.googleAuthProvider;
+        isProviderEnabled = provider && provider.clientID;
+        break;
+
+      default:
+        throw new Error(
+          `Authentication provider, ${providerType}, is not supported.`
+        );
+    }
+
+    if (isProviderEnabled) {
+      req.provider = provider;
+    } else {
+      throw new CustomError(message, 401);
+    }
+
+    next();
+  };
+};
+
 const unknownRoutes = (request, response, next) => {
   // This middleware returns response when client tries to access unknown routes through this domain
-  response.status(404).send({ error: 'unknown endpoint' });
+  response.status(404).send({ error: "unknown endpoint" });
 };
 
 const errorHandler = (error, request, response, next) => {
   // This middleware handles errors responses sent to client
   console.log(error);
-  if (error.name === 'ValidationError') {
-    response.status(400).json(
-      CustomResponse('ValidationError', { statusCode: 422, message: error.message }, false)
-    );
-  } else if (error.name === 'SyntaxError') {
-    response.status(401).json(
-      CustomResponse('SyntaxError', { statusCode: 422, message: error.message }, false)
-    );
-  } else if (error.name === 'JsonWebTokenError') {
-    response.status(401).json(
-      CustomResponse('JsonWebTokenError', { statusCode: 401, message: error.message }, false)
-    );
-  } else if (error.name === 'CustomError') {
-    response.status(error.status).json(
-      CustomResponse(error.message, { statusCode: error.status, message: error.message }, false)
-    );
+  if (error.name === "ValidationError") {
+    response
+      .status(400)
+      .json(
+        CustomResponse(
+          "ValidationError",
+          { statusCode: 422, message: error.message },
+          false
+        )
+      );
+  } else if (error.name === "SyntaxError") {
+    response
+      .status(401)
+      .json(
+        CustomResponse(
+          "SyntaxError",
+          { statusCode: 422, message: error.message },
+          false
+        )
+      );
+  } else if (error.name === "JsonWebTokenError") {
+    response
+      .status(401)
+      .json(
+        CustomResponse(
+          "JsonWebTokenError",
+          { statusCode: 401, message: error.message },
+          false
+        )
+      );
+  } else if (error.name === "CustomError") {
+    response
+      .status(error.status)
+      .json(
+        CustomResponse(
+          error.message,
+          { statusCode: error.status, message: error.message },
+          false
+        )
+      );
   } else {
-    response.status(500).json(CustomResponse('Unhandled Error', error = { statusCode: 500, message: 'Unhandled Error' }, false));
+    response
+      .status(500)
+      .json(
+        CustomResponse(
+          "Unhandled Error",
+          (error = { statusCode: 500, message: "Unhandled Error" }),
+          false
+        )
+      );
   }
   // next(error);
 };
-
 
 module.exports = {
   authorizeUser,
   auth,
   errorHandler,
-  unknownRoutes
+  unknownRoutes,
+  twitterAuthProvider,
+  facebookAuthProvider,
+  githubAuthProvider,
+  googleAuthProvider,
 };

--- a/src/models/admin.js
+++ b/src/models/admin.js
@@ -1,33 +1,38 @@
-const mongoose = require('mongoose');
-const mongodbErrorHandler = require('mongoose-mongodb-errors');
-const bcrypt = require('bcrypt');
-const jwt = require('jsonwebtoken');
-const findOrCreate = require('mongoose-findorcreate');
+const mongoose = require("mongoose");
+const mongodbErrorHandler = require("mongoose-mongodb-errors");
+const bcrypt = require("bcrypt");
+const jwt = require("jsonwebtoken");
+const findOrCreate = require("mongoose-findorcreate");
 // const moment = require('moment');
 const saltRounds = 10;
-const { JWT_EXPIRE, JWT_SECRET, JWT_ADMIN_SECRET, AUTH_API_DB } = require('../utils/config');
+const {
+  JWT_EXPIRE,
+  JWT_SECRET,
+  JWT_ADMIN_SECRET,
+  AUTH_API_DB,
+} = require("../utils/config");
 
 // Modified user model
 const userSchema = new mongoose.Schema({
   username: {
     type: String,
     uniqueCaseInsensitive: true,
-    required: [true, 'Please add a name'],
+    required: [true, "Please add a name"],
   },
   email: {
     type: String,
     uniqueCaseInsensitive: true,
-    required: [true, 'Please enter an email'],
+    required: [true, "Please enter an email"],
   },
   password: {
     type: String,
-    required: [true, 'Please enter a Password'],
+    required: [true, "Please enter a Password"],
     minlength: 8,
     // select: false,
   },
   phone_number: {
     type: String,
-    required: [true, 'Please enter a phone number'],
+    required: [true, "Please enter a phone number"],
     min: 10,
   },
   resetPasswordToken: String,
@@ -36,18 +41,22 @@ const userSchema = new mongoose.Schema({
     type: Date,
     default: Date.now,
   },
+  settings: {
+    type: mongoose.Schema.Types.ObjectId,
+    ref: "Settings",
+  },
 });
 userSchema.plugin(findOrCreate);
 userSchema.plugin(mongodbErrorHandler);
 
 // remove password, _id and return id instead whenever user is retrieved from db
-userSchema.set('toJSON', {
+userSchema.set("toJSON", {
   virtuals: true,
   versionKey: false,
   transform: (document, returnedObject) => {
     delete returnedObject._id;
     delete returnedObject.password;
-  }
+  },
 });
 
 userSchema.methods.matchPasswords = async function (enteredPassword) {
@@ -55,7 +64,7 @@ userSchema.methods.matchPasswords = async function (enteredPassword) {
   return await bcrypt.compare(enteredPassword, this.password);
 };
 
-userSchema.pre('save', function () {
+userSchema.pre("save", function () {
   // Check if password is present and is modified, then hash
   const user = this;
 
@@ -73,7 +82,7 @@ userSchema.methods.generateAPIKEY = function () {
     {
       id: admin.id,
       email: admin.email,
-      DBURI: AUTH_API_DB
+      DBURI: AUTH_API_DB,
     },
     JWT_ADMIN_SECRET
   );
@@ -85,7 +94,7 @@ userSchema.statics.findByToken = function (token, cb) {
   jwt.verify(token, JWT_SECRET, (err, decode) => {
     if (err) {
       return cb(err);
-    };
+    }
     user.findOne({ id: decode, token }, (err, user) => {
       if (err) {
         return cb(err);
@@ -95,4 +104,4 @@ userSchema.statics.findByToken = function (token, cb) {
   });
 };
 
-module.exports = mongoose.model('adminUser', userSchema);
+module.exports = mongoose.model("adminUser", userSchema);

--- a/src/models/settings.js
+++ b/src/models/settings.js
@@ -17,7 +17,7 @@ const GitHubAuthProviderCredentialsSchema = new mongoose.Schema({});
 // Settings model
 const settingsSchema = new mongoose.Schema({
   facebookAuthProvider: {
-    appId: {
+    appID: {
       type: String,
     },
     appSecret: {
@@ -33,7 +33,7 @@ const settingsSchema = new mongoose.Schema({
     },
   },
   githubAuthProvider: {
-    clientId: {
+    clientID: {
       type: String,
     },
     clientSecret: {
@@ -41,7 +41,7 @@ const settingsSchema = new mongoose.Schema({
     },
   },
   googleAuthProvider: {
-    clientId: {
+    clientID: {
       type: String,
     },
     clientSecret: {

--- a/src/models/settings.js
+++ b/src/models/settings.js
@@ -1,0 +1,66 @@
+const mongoose = require("mongoose");
+const mongodbErrorHandler = require("mongoose-mongodb-errors");
+const findOrCreate = require("mongoose-findorcreate");
+
+// Subschema for the Facebook authentication provider credentials.
+const FacebookAuthProviderCredentialsSchema = new mongoose.Schema({});
+
+// Subschema for the Twitter authentication provider credentials.
+const TwitterAuthProviderCredentialsSchema = new mongoose.Schema({});
+
+// Subschema for the Google authentication provider credentials.
+const GoogleAuthProviderCredentialsSchema = new mongoose.Schema({});
+
+// Subschema for the GitHub authentication provider credentials.
+const GitHubAuthProviderCredentialsSchema = new mongoose.Schema({});
+
+// Settings model
+const settingsSchema = new mongoose.Schema({
+  facebookAuthProvider: {
+    appId: {
+      type: String,
+    },
+    appSecret: {
+      type: String,
+    },
+  },
+  twitterAuthProvider: {
+    key: {
+      type: String,
+    },
+    secret: {
+      type: String,
+    },
+  },
+  githubAuthProvider: {
+    clientId: {
+      type: String,
+    },
+    clientSecret: {
+      type: String,
+    },
+  },
+  googleAuthProvider: {
+    clientId: {
+      type: String,
+    },
+    clientSecret: {
+      type: String,
+    },
+  },
+});
+
+settingsSchema.plugin(findOrCreate);
+settingsSchema.plugin(mongodbErrorHandler);
+
+// remove password, _id and return id instead whenever user is retrieved from db
+settingsSchema.set("toJSON", {
+  virtuals: true,
+  versionKey: false,
+  transform: (document, returnedObject) => {
+    delete returnedObject._id;
+    delete returnedObject.__v;
+  },
+});
+
+module.exports = mongoose.model("Settings", settingsSchema);

--- a/src/models/settings.js
+++ b/src/models/settings.js
@@ -2,50 +2,46 @@ const mongoose = require("mongoose");
 const mongodbErrorHandler = require("mongoose-mongodb-errors");
 const findOrCreate = require("mongoose-findorcreate");
 
-// Subschema for the Facebook authentication provider credentials.
-const FacebookAuthProviderCredentialsSchema = new mongoose.Schema({});
-
-// Subschema for the Twitter authentication provider credentials.
-const TwitterAuthProviderCredentialsSchema = new mongoose.Schema({});
-
-// Subschema for the Google authentication provider credentials.
-const GoogleAuthProviderCredentialsSchema = new mongoose.Schema({});
-
-// Subschema for the GitHub authentication provider credentials.
-const GitHubAuthProviderCredentialsSchema = new mongoose.Schema({});
-
 // Settings model
 const settingsSchema = new mongoose.Schema({
   facebookAuthProvider: {
     appID: {
       type: String,
+      default: null,
     },
     appSecret: {
       type: String,
+      default: null,
     },
   },
   twitterAuthProvider: {
     key: {
       type: String,
+      default: null,
     },
     secret: {
       type: String,
+      default: null,
     },
   },
   githubAuthProvider: {
     clientID: {
       type: String,
+      default: null,
     },
     clientSecret: {
       type: String,
+      default: null,
     },
   },
   googleAuthProvider: {
     clientID: {
       type: String,
+      default: null,
     },
     clientSecret: {
       type: String,
+      default: null,
     },
   },
 });
@@ -58,6 +54,7 @@ settingsSchema.set("toJSON", {
   virtuals: true,
   versionKey: false,
   transform: (document, returnedObject) => {
+    delete returnedObject.id;
     delete returnedObject._id;
     delete returnedObject.__v;
   },

--- a/src/models/user.js
+++ b/src/models/user.js
@@ -76,10 +76,6 @@ const userSchema = new mongoose.Schema({
     required: true,
     default: 1,
   },
-  adminId: {
-    type: mongoose.Schema.Types.ObjectId,
-    refs: "Admin",
-  },
 });
 
 userSchema.plugin(mongodbErrorHandler);

--- a/src/models/user.js
+++ b/src/models/user.js
@@ -58,22 +58,6 @@ const userSchema = new mongoose.Schema({
     type: Boolean,
     default: false,
   },
-  twitterEnabled: {
-    type: Boolean,
-    default: false,
-  },
-  facebookEnabled: {
-    type: Boolean,
-    default: false,
-  },
-  githubEnabled: {
-    type: Boolean,
-    default: false,
-  },
-  googleEnabled: {
-    type: Boolean,
-    default: false,
-  },
   twitter: String,
   facebook: String,
   github: String,
@@ -91,6 +75,10 @@ const userSchema = new mongoose.Schema({
     enum: [0, 1],
     required: true,
     default: 1,
+  },
+  adminId: {
+    type: mongoose.Schema.Types.ObjectId,
+    refs: "Admin",
   },
 });
 

--- a/src/models/user.js
+++ b/src/models/user.js
@@ -1,28 +1,27 @@
-const mongoose = require('mongoose');
-const mongodbErrorHandler = require('mongoose-mongodb-errors');
-const bcrypt = require('bcrypt');
-const jwt = require('jsonwebtoken');
-const findOrCreate = require('mongoose-findorcreate');
+const mongoose = require("mongoose");
+const mongodbErrorHandler = require("mongoose-mongodb-errors");
+const bcrypt = require("bcrypt");
+const jwt = require("jsonwebtoken");
+const findOrCreate = require("mongoose-findorcreate");
 const saltRounds = 10;
-const { JWT_EXPIRE, JWT_SECRET } = require('../utils/config');
-
+const { JWT_EXPIRE, JWT_SECRET } = require("../utils/config");
 
 // Modified user model
 const userSchema = new mongoose.Schema({
   username: {
     type: String,
     uniqueCaseInsensitive: true,
-    required: [true, 'Please add a name'],
+    required: [true, "Please add a name"],
   },
   twoFactorAuth: {
     is2FA: {
       type: Boolean,
-      default: false
+      default: false,
     },
     status: {
       type: String,
-      default: null
-    }
+      default: null,
+    },
   },
   failedAttempts: {
     count: {
@@ -36,7 +35,7 @@ const userSchema = new mongoose.Schema({
   email: {
     type: String,
     uniqueCaseInsensitive: true,
-    required: [true, 'Please enter an email'],
+    required: [true, "Please enter an email"],
   },
   password: {
     type: String,
@@ -56,6 +55,22 @@ const userSchema = new mongoose.Schema({
     default: Date.now,
   },
   isEmailVerified: {
+    type: Boolean,
+    default: false,
+  },
+  twitterEnabled: {
+    type: Boolean,
+    default: false,
+  },
+  facebookEnabled: {
+    type: Boolean,
+    default: false,
+  },
+  githubEnabled: {
+    type: Boolean,
+    default: false,
+  },
+  googleEnabled: {
     type: Boolean,
     default: false,
   },
@@ -82,7 +97,7 @@ const userSchema = new mongoose.Schema({
 userSchema.plugin(mongodbErrorHandler);
 userSchema.plugin(findOrCreate);
 // remove password, _id and return id instead whenever user is retrieved from db
-userSchema.set('toJSON', {
+userSchema.set("toJSON", {
   virtuals: true,
   versionKey: false,
   transform: (document, returnedObject) => {
@@ -96,11 +111,11 @@ userSchema.methods.matchPasswords = async function (enteredPassword) {
   return await bcrypt.compare(enteredPassword, this.password);
 };
 
-userSchema.pre('save', function () {
+userSchema.pre("save", function () {
   // Check if password is present and is modified, then hash
   const user = this;
 
-  if (user.password && user.isModified('password')) {
+  if (user.password && user.isModified("password")) {
     user.password = bcrypt.hashSync(user.password, saltRounds);
   }
 });
@@ -118,7 +133,7 @@ userSchema.methods.generateToken = async function () {
 userSchema.statics.findByToken = function (token, cb) {
   let user = this;
 
-  jwt.verify(token, 'secret', (err, decode) => {
+  jwt.verify(token, "secret", (err, decode) => {
     user.findOne({ _id: decode, token: token }, (err, user) => {
       if (err) {
         return cb(err);
@@ -128,4 +143,4 @@ userSchema.statics.findByToken = function (token, cb) {
   });
 };
 
-module.exports = mongoose.model('User', userSchema);
+module.exports = mongoose.model("User", userSchema);

--- a/src/routes/adminAuth.js
+++ b/src/routes/adminAuth.js
@@ -1,16 +1,40 @@
-const adminRouter = require('express').Router();
-const { registerValidation, loginValidation, forgotValidation, resetPasswordValidation } = require('../utils/validation/joiValidation');
-const AdminCtrl = require('../controllers/admin');
+const adminRouter = require("express").Router();
+const {
+  registerValidation,
+  loginValidation,
+  updateSettingsValidation,
+  forgotValidation,
+  resetPasswordValidation,
+} = require("../utils/validation/joiValidation");
+const AdminCtrl = require("../controllers/admin");
 
 module.exports = () => {
-  adminRouter.post('/register', registerValidation(), AdminCtrl.register);
-  adminRouter.post('/getkey', loginValidation(), AdminCtrl.getKey);
-  adminRouter.post('/reset-password', forgotValidation(), AdminCtrl.forgotPassword);
+  adminRouter.post("/register", registerValidation(), AdminCtrl.register);
+  adminRouter.post("/getkey", loginValidation(), AdminCtrl.getKey);
+  adminRouter.post(
+    "/reset-password",
+    forgotValidation(),
+    AdminCtrl.forgotPassword
+  );
+  adminRouter.get("/settings", AdminCtrl.getSettings);
+  adminRouter.patch(
+    "/settings",
+    updateSettingsValidation(),
+    AdminCtrl.updateSettings
+  );
   /* I'll deal with this later */
-  adminRouter.get('/reset-password/:token', (request, response, next) => {
-    response.status(200).send('It\'s cool you\'re here 😁, but you should be using postman to send a PATCH request to change password via this url!');
+  adminRouter.get("/reset-password/:token", (request, response, next) => {
+    response
+      .status(200)
+      .send(
+        "It's cool you're here 😁, but you should be using postman to send a PATCH request to change password via this url!"
+      );
   });
-  adminRouter.patch('/reset-password/:token', resetPasswordValidation(), AdminCtrl.resetPassword);
+  adminRouter.patch(
+    "/reset-password/:token",
+    resetPasswordValidation(),
+    AdminCtrl.resetPassword
+  );
 
   return adminRouter;
 };

--- a/src/routes/adminAuth.js
+++ b/src/routes/adminAuth.js
@@ -2,6 +2,7 @@ const adminRouter = require("express").Router();
 const {
   registerValidation,
   loginValidation,
+  getSettingsValidation,
   updateSettingsValidation,
   forgotValidation,
   resetPasswordValidation,
@@ -16,7 +17,7 @@ module.exports = () => {
     forgotValidation(),
     AdminCtrl.forgotPassword
   );
-  adminRouter.get("/settings", AdminCtrl.getSettings);
+  adminRouter.get("/settings", getSettingsValidation(), AdminCtrl.getSettings);
   adminRouter.patch(
     "/settings",
     updateSettingsValidation(),

--- a/src/routes/adminAuth.js
+++ b/src/routes/adminAuth.js
@@ -1,4 +1,5 @@
 const adminRouter = require("express").Router();
+const { authorizeUser } = require("../middlewares/middleware");
 const {
   registerValidation,
   loginValidation,
@@ -17,9 +18,15 @@ module.exports = () => {
     forgotValidation(),
     AdminCtrl.forgotPassword
   );
-  adminRouter.get("/settings", getSettingsValidation(), AdminCtrl.getSettings);
+  adminRouter.get(
+    "/settings",
+    authorizeUser,
+    getSettingsValidation(),
+    AdminCtrl.getSettings
+  );
   adminRouter.patch(
     "/settings",
+    authorizeUser,
     updateSettingsValidation(),
     AdminCtrl.updateSettings
   );

--- a/src/routes/auth.js
+++ b/src/routes/auth.js
@@ -3,12 +3,11 @@ const {
   registerValidation,
   loginValidation,
 } = require("../utils/validation/joiValidation");
-const { auth, authorizeUser } = require("../middlewares/middleware");
+const { authorizeUser } = require("../middlewares/middleware");
 const UserController = require("../controllers/auth");
 const {
   forgotValidation,
   resetPasswordValidation,
-  updateAuthProvidersValidation,
 } = require("../utils/validation/joiValidation");
 const SessionMgt = require("../services/SessionManagement");
 
@@ -39,7 +38,7 @@ module.exports = () => {
 
   userRouter
     .route("/register")
-    .get(SessionMgt.checkSession, (request, response) => {
+    .get(authorizeUser, SessionMgt.checkSession, (request, response) => {
       response.status(200).json({
         success: true,
       });
@@ -61,12 +60,6 @@ module.exports = () => {
     //   response.redirect('/');
     // })
     .get(UserController.otpVerify);
-
-  userRouter.patch(
-    "/providers",
-    updateAuthProvidersValidation(),
-    UserController.updateAuthProviders
-  );
 
   userRouter.get("/logout", async (request, response) => {
     response.clearCookie("user_sid", { path: "/" });

--- a/src/routes/auth.js
+++ b/src/routes/auth.js
@@ -30,7 +30,7 @@ module.exports = () => {
     .get(UserController.activeUser);
 
   userRouter
-    .route("/enable")
+    .route("/enable2fa")
     // .get(SessionMgt.checkSession, (request, response) => {
     //   response.redirect('/');
     // })

--- a/src/routes/auth.js
+++ b/src/routes/auth.js
@@ -1,13 +1,18 @@
-const userRouter = require('express').Router();
-const { registerValidation, loginValidation } = require('../utils/validation/joiValidation');
-const { auth, authorizeUser } = require('../middlewares/middleware');
-const UserController = require('../controllers/auth');
-const { forgotValidation, resetPasswordValidation } = require('../utils/validation/joiValidation');
-const SessionMgt = require('../services/SessionManagement');
-
+const userRouter = require("express").Router();
+const {
+  registerValidation,
+  loginValidation,
+} = require("../utils/validation/joiValidation");
+const { auth, authorizeUser } = require("../middlewares/middleware");
+const UserController = require("../controllers/auth");
+const {
+  forgotValidation,
+  resetPasswordValidation,
+  updateAuthProvidersValidation,
+} = require("../utils/validation/joiValidation");
+const SessionMgt = require("../services/SessionManagement");
 
 module.exports = () => {
-
   // userRouter.get('/active', auth, (req, res) => {
   //   res.status(200).json({
   //     _id: req.user.id,
@@ -18,60 +23,77 @@ module.exports = () => {
   //   });
   // });
 
-  userRouter.route('/active')
+  userRouter
+    .route("/active")
     // .get(SessionMgt.checkSession, (request, response) => {
     //   response.redirect('/');
     // })
     .get(UserController.activeUser);
 
-  userRouter.route('/enable')
+  userRouter
+    .route("/enable")
     // .get(SessionMgt.checkSession, (request, response) => {
     //   response.redirect('/');
     // })
     .get(UserController.enable2FA);
 
-  userRouter.route('/register')
+  userRouter
+    .route("/register")
     .get(SessionMgt.checkSession, (request, response) => {
       response.status(200).json({
-        success: true
+        success: true,
       });
     })
     .post(registerValidation(), UserController.register);
 
-  userRouter.route('/login')
+  userRouter
+    .route("/login")
     .get(SessionMgt.checkSession, (request, response) => {
       response.status(200).json({
-        success: true
+        success: true,
       });
     })
     .post(loginValidation(), UserController.login);
 
-  userRouter.route('/verify')
+  userRouter
+    .route("/verify")
     // .get(SessionMgt.checkSession, (request, response) => {
     //   response.redirect('/');
     // })
     .get(UserController.otpVerify);
 
-  userRouter.get('/logout', async (request, response) => {
-    response.clearCookie('user_sid', { path: '/' });
+  userRouter.patch(
+    "/providers",
+    updateAuthProvidersValidation(),
+    UserController.updateAuthProviders
+  );
+
+  userRouter.get("/logout", async (request, response) => {
+    response.clearCookie("user_sid", { path: "/" });
 
     request.session.destroy();
 
     // response.redirect('/');
     response.status(200).json({
       success: true,
-      message: 'Redirect user to login at GET: /api/user/login'
+      message: "Redirect user to login at GET: /api/user/login",
     });
   });
 
-  userRouter.post('/reset', forgotValidation(), UserController.forgotPassword);
+  userRouter.post("/reset", forgotValidation(), UserController.forgotPassword);
 
-  userRouter.get('/:token', (request, response, next) => {
-    response.redirect(`https://upbeat-leavitt-2a7b54.netlify.app/pages/forgot-new/?token=${request.params.token}`);
+  userRouter.get("/:token", (request, response, next) => {
+    response.redirect(
+      `https://upbeat-leavitt-2a7b54.netlify.app/pages/forgot-new/?token=${request.params.token}`
+    );
   });
 
-  userRouter.patch('/:token', authorizeUser, resetPasswordValidation(), UserController.resetPassword);
+  userRouter.patch(
+    "/:token",
+    authorizeUser,
+    resetPasswordValidation(),
+    UserController.resetPassword
+  );
 
   return userRouter;
 };
-

--- a/src/routes/auth.js
+++ b/src/routes/auth.js
@@ -43,7 +43,7 @@ module.exports = () => {
         success: true,
       });
     })
-    .post(registerValidation(), UserController.register);
+    .post(authorizeUser, registerValidation(), UserController.register);
 
   userRouter
     .route("/login")

--- a/src/routes/documentation.js
+++ b/src/routes/documentation.js
@@ -1,0 +1,15 @@
+const router = require("express").Router();
+const swaggerUi = require("swagger-ui-express");
+const openApiDocumentation = require("../swagger/openApiDocumentation");
+
+const swaggerUiOptions = {
+  customSiteTitle: "MicroAPI | Authentication API Documentation",
+  customCss: ".swagger-ui .topbar { display: none }",
+};
+
+// use swagger-ui-express for your app documentation endpoint
+router.use("/", swaggerUi.serve);
+router.get("/", swaggerUi.setup(openApiDocumentation, swaggerUiOptions));
+router.get("/docs", swaggerUi.setup(openApiDocumentation, swaggerUiOptions));
+
+module.exports = router;

--- a/src/routes/documentation.js
+++ b/src/routes/documentation.js
@@ -7,9 +7,27 @@ const swaggerUiOptions = {
   customCss: ".swagger-ui .topbar { display: none }",
 };
 
+const jsonMiddleware = (req, res, next) => {
+  const { format } = req.query;
+
+  if (format && format.toString() === "json") {
+    res.send(JSON.stringify(openApiDocumentation));
+  } else {
+    next();
+  }
+};
+
 // use swagger-ui-express for your app documentation endpoint
 router.use("/", swaggerUi.serve);
-router.get("/", swaggerUi.setup(openApiDocumentation, swaggerUiOptions));
-router.get("/docs", swaggerUi.setup(openApiDocumentation, swaggerUiOptions));
+router.get(
+  "/",
+  jsonMiddleware,
+  swaggerUi.setup(openApiDocumentation, swaggerUiOptions)
+);
+router.get(
+  "/docs",
+  jsonMiddleware,
+  swaggerUi.setup(openApiDocumentation, swaggerUiOptions)
+);
 
 module.exports = router;

--- a/src/routes/fbauth.js
+++ b/src/routes/fbauth.js
@@ -2,12 +2,15 @@ require("dotenv").config();
 const fbRouter = require("express").Router();
 const passport = require("passport");
 const createFacebookStrategy = require("../config/passport/facebookStrategy");
+const {
+  authorizeUser,
+  facebookAuthProvider,
+} = require("../middlewares/middleware");
 
-fbRouter.get(
-  "/",
-  passport.authenticate(createFacebookStrategy(), {
+fbRouter.get("/", authorizeUser, facebookAuthProvider, (req, res, next) =>
+  passport.authenticate(createFacebookStrategy(req.provider), {
     scope: ["email", "public_profile"],
-  })
+  })(req, res, next)
 );
 
 fbRouter.get(

--- a/src/routes/fbauth.js
+++ b/src/routes/fbauth.js
@@ -1,17 +1,25 @@
-require('dotenv').config();
-const fbRouter = require('express').Router();
-const passport = require('passport');
+require("dotenv").config();
+const fbRouter = require("express").Router();
+const passport = require("passport");
+const createFacebookStrategy = require("../config/passport/facebookStrategy");
 
+fbRouter.get(
+  "/",
+  passport.authenticate(createFacebookStrategy(), {
+    scope: ["email", "public_profile"],
+  })
+);
 
-
-
-fbRouter.get('/', passport.authenticate('facebook', { scope: ['email', 'public_profile'] }));
-
-fbRouter.get('/callback',
-  passport.authenticate('facebook', { failureRedirect: '/login' }),
+fbRouter.get(
+  "/callback",
+  passport.authenticate(createFacebookStrategy(), {
+    failureRedirect: "/login",
+  }),
   (req, res) => {
-    res.redirect('https://upbeat-leavitt-2a7b54.netlify.app/pages/dashboard.html');
-  });
-
+    res.redirect(
+      "https://upbeat-leavitt-2a7b54.netlify.app/pages/dashboard.html"
+    );
+  }
+);
 
 module.exports = fbRouter;

--- a/src/routes/gitauth.js
+++ b/src/routes/gitauth.js
@@ -2,8 +2,14 @@ require("dotenv").config();
 const gitRouter = require("express").Router();
 const passport = require("passport");
 const createGithubStrategy = require("../config/passport/githubStrategy");
+const {
+  authorizeUser,
+  githubAuthProvider,
+} = require("../middlewares/middleware");
 
-gitRouter.get("/", passport.authenticate(createGithubStrategy()));
+gitRouter.get("/", authorizeUser, githubAuthProvider, (req, res, next) =>
+  passport.authenticate(createGithubStrategy(req.provider))(req, res, next)
+);
 
 gitRouter.get(
   "/callback",

--- a/src/routes/gitauth.js
+++ b/src/routes/gitauth.js
@@ -1,36 +1,19 @@
-require('dotenv').config();
-const gitRouter = require('express').Router();
-const Admin = require('../models/admin');
-const User = require('../models/user');
-const passport = require('passport');
-const GitHubStrategy = require('passport-github').Strategy;
-const findOrCreate = require('mongoose-findorcreate');
+require("dotenv").config();
+const gitRouter = require("express").Router();
+const passport = require("passport");
+const createGithubStrategy = require("../config/passport/githubStrategy");
 
+gitRouter.get("/", passport.authenticate(createGithubStrategy()));
 
-// use static serialize and deserialize of model for passport session support
-passport.serializeUser((user, done) => {
-  done(null, user.id);
-});
-
-passport.deserializeUser((id, done) => {
-
-  User.findById(id, (err, user) => {
-    done(err, user);
-  });
-
-});
-
-
-gitRouter.get('/',
-  passport.authenticate('github'));
-
-gitRouter.get('/callback',
-  passport.authenticate('github', { failureRedirect: '/login' }),
+gitRouter.get(
+  "/callback",
+  passport.authenticate(createGithubStrategy(), { failureRedirect: "/login" }),
   (req, res) => {
     // Successful authentication, redirect home.
-    res.redirect('https://upbeat-leavitt-2a7b54.netlify.app/pages/dashboard.html');
-  });
-
-
+    res.redirect(
+      "https://upbeat-leavitt-2a7b54.netlify.app/pages/dashboard.html"
+    );
+  }
+);
 
 module.exports = gitRouter;

--- a/src/routes/googleLogin.js
+++ b/src/routes/googleLogin.js
@@ -16,7 +16,7 @@ route.get(
 route.get(
   "/callback",
   passport.authenticate(createGoogleStrategy(), {
-    failureRedirect: "/api/auth/google",
+    failureRedirect: "/api/google",
   }),
   (req, res) => {
     console.log(req.user);

--- a/src/routes/googleLogin.js
+++ b/src/routes/googleLogin.js
@@ -1,25 +1,31 @@
-const express = require('express');
-const User = require('../models/user');
-const passport = require('passport');
+const express = require("express");
+const passport = require("passport");
+const createGoogleStrategy = require("../config/passport/googleStrategy");
 const route = express.Router();
 
-route.get('/', passport.authenticate('google', { 
-  scope: [
-    'https://www.googleapis.com/auth/userinfo.profile',
-    'https://www.googleapis.com/auth/userinfo.email'
-  ]
-})
+route.get(
+  "/",
+  passport.authenticate(createGoogleStrategy(), {
+    scope: [
+      "https://www.googleapis.com/auth/userinfo.profile",
+      "https://www.googleapis.com/auth/userinfo.email",
+    ],
+  })
 );
 
-route.get('/callback', 
-  passport.authenticate('google', {failureRedirect: '/api/auth/google'}), 
+route.get(
+  "/callback",
+  passport.authenticate(createGoogleStrategy(), {
+    failureRedirect: "/api/auth/google",
+  }),
   (req, res) => {
     console.log(req.user);
     res.status(200).json({
       success: true,
-      message: 'Google authenticated',
-      user: req.user
+      message: "Google authenticated",
+      user: req.user,
     });
-  });
+  }
+);
 
 module.exports = route;

--- a/src/routes/googleLogin.js
+++ b/src/routes/googleLogin.js
@@ -1,16 +1,20 @@
 const express = require("express");
 const passport = require("passport");
 const createGoogleStrategy = require("../config/passport/googleStrategy");
+const {
+  authorizeUser,
+  googleAuthProvider,
+} = require("../middlewares/middleware");
+const Admin = require("../models/admin");
 const route = express.Router();
 
-route.get(
-  "/",
-  passport.authenticate(createGoogleStrategy(), {
+route.get("/", authorizeUser, googleAuthProvider, (req, res, next) =>
+  passport.authenticate(createGoogleStrategy(req.provider), {
     scope: [
       "https://www.googleapis.com/auth/userinfo.profile",
       "https://www.googleapis.com/auth/userinfo.email",
     ],
-  })
+  })(req, res, next)
 );
 
 route.get(
@@ -19,7 +23,6 @@ route.get(
     failureRedirect: "/api/google",
   }),
   (req, res) => {
-    console.log(req.user);
     res.status(200).json({
       success: true,
       message: "Google authenticated",

--- a/src/routes/twitterAuth.js
+++ b/src/routes/twitterAuth.js
@@ -1,15 +1,18 @@
-require('dotenv').config();
-const twitterRoute = require('express').Router();
-const passport = require('passport');
+require("dotenv").config();
+const twitterRoute = require("express").Router();
+const passport = require("passport");
+const createTwitterStrategy = require("../config/passport/twitterStrategy");
 
-twitterRoute.get('/', passport.authenticate('twitter'));
+twitterRoute.get("/", passport.authenticate(createTwitterStrategy()));
 
 twitterRoute.get(
-  '/callback',
-  passport.authenticate('twitter', { failureRedirect: '/login' }),
+  "/callback",
+  passport.authenticate(createTwitterStrategy(), { failureRedirect: "/login" }),
   (req, res) => {
     // Successful authentication, redirect home.
-    res.redirect('https://upbeat-leavitt-2a7b54.netlify.app/pages/dashboard.html');
+    res.redirect(
+      "https://upbeat-leavitt-2a7b54.netlify.app/pages/dashboard.html"
+    );
   }
 );
 

--- a/src/routes/twitterAuth.js
+++ b/src/routes/twitterAuth.js
@@ -2,8 +2,14 @@ require("dotenv").config();
 const twitterRoute = require("express").Router();
 const passport = require("passport");
 const createTwitterStrategy = require("../config/passport/twitterStrategy");
+const {
+  authorizeUser,
+  twitterAuthProvider,
+} = require("../middlewares/middleware");
 
-twitterRoute.get("/", passport.authenticate(createTwitterStrategy()));
+twitterRoute.get("/", authorizeUser, twitterAuthProvider, (req, res, next) =>
+  passport.authenticate(createTwitterStrategy(req.provider))(req, res, next)
+);
 
 twitterRoute.get(
   "/callback",

--- a/src/services/adminAuth.js
+++ b/src/services/adminAuth.js
@@ -81,7 +81,7 @@ class AdminService {
     const { body, admin } = req;
 
     // New API KEY for admin
-    const user = await await await Admin.findOne({ email: admin.email });
+    const user = await Admin.findOne({ email: admin.email });
 
     if (!user) {
       throw new CustomError("Admin with email not found", 404);

--- a/src/services/adminAuth.js
+++ b/src/services/adminAuth.js
@@ -1,7 +1,7 @@
 const mongoose = require("mongoose");
 const Admin = require("../models/admin");
 const Settings = require("../models/settings");
-const CustomError = require("../utils/CustomError");
+const { CustomError } = require("../utils/CustomError");
 const RandomString = require("randomstring");
 const { sendForgotPasswordMail } = require("../EmailFactory/index");
 
@@ -67,7 +67,7 @@ class AdminService {
       throw new CustomError("Admin with email not found", 404);
     }
 
-    const data = user;
+    const data = user.settings;
     const message = "Settings retrieved successfully";
 
     return {

--- a/src/services/adminAuth.js
+++ b/src/services/adminAuth.js
@@ -1,25 +1,27 @@
-const mongoose = require('mongoose');
-const Admin = require('../models/admin');
-const CustomError = require('../utils/CustomError');
-const RandomString = require('randomstring');
-const crypto = require('crypto');
-const bcrypt = require('bcrypt');
-const { sendForgotPasswordMail } = require('../EmailFactory/index');
+const mongoose = require("mongoose");
+const Admin = require("../models/admin");
+const Settings = require("../models/settings");
+const CustomError = require("../utils/CustomError");
+const RandomString = require("randomstring");
+const { sendForgotPasswordMail } = require("../EmailFactory/index");
 
-class AdminService{
-  async register(body){    
-    // Adds a new admin to Auth-MicroApi DB   
+class AdminService {
+  async register(body) {
+    // Adds a new admin to Auth-MicroApi DB
     let user = await Admin.findOne({ email: body.email });
     if (user) {
-      throw new CustomError('Email address already in use', 403);
+      throw new CustomError("Email address already in use", 403);
     }
     // const myDB = mongoose.connection.useDb();
-  
+
     // const UserInfo = myDB.model('userInfo', userInfoSchema);
-  
-    user = new Admin(body);
+
+    let settings = new Settings();
+    settings = await settings.save();
+
+    user = new Admin({ ...body, settings: settings._id });
     user = await user.save();
-  
+
     // DON'T DELETE: Admin acc. verification
     // Send a confirmation link to email
     // const mailStatus = await createVerificationLink(user, request);
@@ -30,30 +32,91 @@ class AdminService{
     return data;
   }
 
-  async getKey(body){
+  async getKey(body) {
     // New API KEY for admin
     let user = await Admin.findOne({ email: body.email });
-  
+
     if (!user) {
-      throw new CustomError('Authentication failed, email not found', 401);
+      throw new CustomError("Authentication failed, email not found", 401);
     }
-  
+
     if (!user.matchPasswords(body.password)) {
-      throw new CustomError('Authentication failed, password is incorrect', 401);
+      throw new CustomError(
+        "Authentication failed, password is incorrect",
+        401
+      );
     }
-  
-    let message = 'API_KEY should be set in authorization header as - Bearer <token> - for subsequent user requests';
+
+    let message =
+      "API_KEY should be set in authorization header as - Bearer <token> - for subsequent user requests";
     let data = { API_KEY: user.generateAPIKEY() };
 
     return {
       data: data,
-      message: message
+      message: message,
     };
-
   }
 
-  async forgotPassword(req){
-    
+  async getSettings(body) {
+    // New API KEY for admin
+    let user = await Admin.findOne({
+      email: body.email,
+    }).populate("settings");
+
+    if (!user) {
+      throw new CustomError("Admin with email not found", 404);
+    }
+
+    const data = user;
+    const message = "Settings retrieved successfully";
+
+    return {
+      data: data,
+      message: message,
+    };
+  }
+
+  async updateSettings(body) {
+    // New API KEY for admin
+    let user = await Admin.findOne({ email: body.email });
+
+    if (!user) {
+      throw new CustomError("Admin with email not found", 404);
+    }
+
+    let settings = await Settings.findById(user.settings);
+
+    if (!settings) {
+      throw new CustomError("Settings not found or deleted", 404);
+    }
+
+    // Update settings with the providers provided in the request body.
+    const {
+      facebookAuthProvider,
+      twitterAuthProvider,
+      githubAuthProvider,
+      googleAuthProvider,
+    } = body;
+
+    await Settings.findByIdAndUpdate(settings.id, {
+      $set: {
+        facebookAuthProvider,
+        twitterAuthProvider,
+        githubAuthProvider,
+        googleAuthProvider,
+      },
+    });
+
+    const data = settings;
+    const message = "Settings updated successfully";
+
+    return {
+      data: data,
+      message: message,
+    };
+  }
+
+  async forgotPassword(req) {
     const { email } = req.body;
     // const buffer = crypto.randomBytes(32);
     // const token = buffer.toString();
@@ -61,97 +124,97 @@ class AdminService{
     const expirationTime = Date.now() + 3600000; // 1 hour
     const admin = await Admin.findOneAndUpdate(
       {
-        email
+        email,
       },
       {
         resetPasswordToken: token,
-        resetPasswordExpire: expirationTime
+        resetPasswordExpire: expirationTime,
       },
       {
-        new: true
+        new: true,
       }
     );
-  
+
     if (!admin) {
       throw new CustomError(
         `Sorry an Account with Email: ${email} doesn't exist on this service`,
-        404,
+        404
       );
     }
-  
+
     const resetUrl = `http:\/\/${req.headers.host}\/api\/auth\/admin\/reset-password\/${token}`;
     sendForgotPasswordMail(admin.email, admin.username, resetUrl);
-    
+
     return {
       url: resetUrl,
-      email: admin.email
+      email: admin.email,
     };
-
   } // end forgotPassword
 
-  async resetPassword(req){
+  async resetPassword(req) {
     const { token } = req.params;
     const { password } = req.body;
     const admin = await Admin.findOneAndUpdate(
       {
         resetPasswordToken: token,
         resetPasswordExpire: {
-          $gt: Date.now()
-        }
+          $gt: Date.now(),
+        },
       },
       {
         password,
         resetPasswordToken: null,
-        resetPasswordExpire: null
+        resetPasswordExpire: null,
       },
       {
-        new: true
+        new: true,
       }
     );
     if (!admin) {
       throw new CustomError(
-        'Password reset token is invalid or has expired.',
-        422,
+        "Password reset token is invalid or has expired.",
+        422
       );
     }
 
     return {
-      status: 'success'
+      status: "success",
     };
-
   } // end resetPassword
 
-  async deactivateUser(req){
+  async deactivateUser(req) {
     const userId = req.params.userId;
-  
-    if(!mongoose.Types.ObjectId.isValid(userId)){
+
+    if (!mongoose.Types.ObjectId.isValid(userId)) {
       return {
-        status: 'fail',
+        status: "fail",
         code: 400,
-        message: 'Invalid user id'
+        message: "Invalid user id",
       };
     }
-  
+
     try {
-      const result = await User.updateOne({_id: userId},{$set: {active : 0}});
-      if(!result){
+      const result = await User.updateOne(
+        { _id: userId },
+        { $set: { active: 0 } }
+      );
+      if (!result) {
         return {
-          status: 'fail',
+          status: "fail",
           code: 400,
-          message: 'User not found.'
+          message: "User not found.",
         };
       }
       return {
-        status: 'success',
+        status: "success",
         code: 200,
-        message: 'User deactivated'
+        message: "User deactivated",
       };
-    }
-    catch(err){
+    } catch (err) {
       return {
-        status: 'error',
+        status: "error",
         code: 500,
-        message: 'Something went wrong.'
+        message: "Something went wrong.",
       };
     }
   }

--- a/src/services/adminAuth.js
+++ b/src/services/adminAuth.js
@@ -59,11 +59,9 @@ class AdminService {
   }
 
   async getSettings(req) {
-    const { body, admin } = req;
-
     // New API KEY for admin
     let user = await Admin.findOne({
-      email: admin.email,
+      email: req.admin.email,
     }).populate("settings");
 
     if (!user) {
@@ -83,16 +81,10 @@ class AdminService {
     const { body, admin } = req;
 
     // New API KEY for admin
-    const user = await Admin.findOne({ email: admin.email });
+    const user = await await await Admin.findOne({ email: admin.email });
 
     if (!user) {
       throw new CustomError("Admin with email not found", 404);
-    }
-
-    let settings = await Settings.findById(user.settings);
-
-    if (!settings) {
-      throw new CustomError("Settings not found or deleted", 404);
     }
 
     // Update settings with the providers provided in the request body.
@@ -114,16 +106,13 @@ class AdminService {
       update.googleAuthProvider = body.googleAuthProvider;
     }
 
-    settings = await Settings.findByIdAndUpdate(settings.id, {
-      $set: update,
+    const settings = await Settings.findByIdAndUpdate(user.settings, update, {
+      new: true,
     });
 
-    const data = settings;
-    const message = "Settings updated successfully";
-
     return {
-      data: data,
-      message: message,
+      data: settings,
+      message: "Settings updated successfully",
     };
   }
 

--- a/src/services/adminAuth.js
+++ b/src/services/adminAuth.js
@@ -1,5 +1,6 @@
 const mongoose = require("mongoose");
 const Admin = require("../models/admin");
+const User = require("../models/user");
 const Settings = require("../models/settings");
 const { CustomError } = require("../utils/CustomError");
 const RandomString = require("randomstring");
@@ -57,10 +58,12 @@ class AdminService {
     };
   }
 
-  async getSettings(body) {
+  async getSettings(req) {
+    const { body, admin } = req;
+
     // New API KEY for admin
     let user = await Admin.findOne({
-      email: body.email,
+      email: admin.email,
     }).populate("settings");
 
     if (!user) {
@@ -76,9 +79,11 @@ class AdminService {
     };
   }
 
-  async updateSettings(body) {
+  async updateSettings(req) {
+    const { body, admin } = req;
+
     // New API KEY for admin
-    let user = await Admin.findOne({ email: body.email });
+    const user = await Admin.findOne({ email: admin.email });
 
     if (!user) {
       throw new CustomError("Admin with email not found", 404);
@@ -91,20 +96,26 @@ class AdminService {
     }
 
     // Update settings with the providers provided in the request body.
-    const {
-      facebookAuthProvider,
-      twitterAuthProvider,
-      githubAuthProvider,
-      googleAuthProvider,
-    } = body;
+    const update = {};
 
-    await Settings.findByIdAndUpdate(settings.id, {
-      $set: {
-        facebookAuthProvider,
-        twitterAuthProvider,
-        githubAuthProvider,
-        googleAuthProvider,
-      },
+    if (body.facebookAuthProvider) {
+      update.facebookAuthProvider = body.facebookAuthProvider;
+    }
+
+    if (body.twitterAuthProvider) {
+      update.twitterAuthProvider = body.twitterAuthProvider;
+    }
+
+    if (body.githubAuthProvider) {
+      update.githubAuthProvider = body.githubAuthProvider;
+    }
+
+    if (body.googleAuthProvider) {
+      update.googleAuthProvider = body.googleAuthProvider;
+    }
+
+    settings = await Settings.findByIdAndUpdate(settings.id, {
+      $set: update,
     });
 
     const data = settings;

--- a/src/services/auth.js
+++ b/src/services/auth.js
@@ -1,5 +1,4 @@
 const RandomString = require("randomstring");
-const Admin = require("../models/admin");
 const User = require("../models/user");
 const SessionMgt = require("../services/SessionManagement");
 const { createVerificationLink } = require("../utils/EmailVerification");
@@ -21,18 +20,7 @@ class UserService {
       throw new CustomError("Email address already in use", 403);
     }
 
-    console.log(admin);
-    const adminDoc = await Admin.findById(admin.id).populate("settings");
-    const settings = adminDoc.settings;
-
-    user = new User({
-      ...body,
-      adminId: admin.id,
-      twitterEnabled: settings.twitterAuthProvider.key !== undefined,
-      facebookEnabled: settings.facebookAuthProvider.appID !== undefined,
-      githubEnabled: settings.githubAuthProvider.clientID !== undefined,
-      googleEnabled: settings.googleAuthProvider.clientID !== undefined,
-    });
+    user = new User(body);
     user = await user.save();
 
     // Send a confirmation link to email

--- a/src/services/auth.js
+++ b/src/services/auth.js
@@ -1,29 +1,28 @@
-const RandomString = require('randomstring');
-const User = require('../models/user');
-const SessionMgt = require('../services/SessionManagement');
-const {createVerificationLink} = require('../utils/EmailVerification');
-const { CustomError } = require('../utils/CustomError');
-const {sendForgotPasswordMail} = require('../EmailFactory');
-const { ACCOUNT_SID, AUTH_TOKEN, SERVICE_ID } = require('../utils/config');
+const RandomString = require("randomstring");
+const User = require("../models/user");
+const SessionMgt = require("../services/SessionManagement");
+const { createVerificationLink } = require("../utils/EmailVerification");
+const { CustomError } = require("../utils/CustomError");
+const { sendForgotPasswordMail } = require("../EmailFactory");
+const { ACCOUNT_SID, AUTH_TOKEN, SERVICE_ID } = require("../utils/config");
 
-const client = require('twilio')(ACCOUNT_SID, AUTH_TOKEN);
+const client = require("twilio")(ACCOUNT_SID, AUTH_TOKEN);
 
-class UserService{
-
-  async register(req){
+class UserService {
+  async register(req) {
     // Register as guest
     const { email } = req.body;
-  
+
     // Check if user email is taken in DB
     let user = await User.findOne({ email });
-  
+
     if (user) {
-      throw new CustomError('Email address already in use', 403);
+      throw new CustomError("Email address already in use", 403);
     }
-  
+
     user = new User({ ...req.body });
     user = await user.save();
-  
+
     // Send a confirmation link to email
     const mailStatus = await createVerificationLink(user, req);
     // console.log(mailStatus);
@@ -32,16 +31,16 @@ class UserService{
       user: user,
       status: mailStatus.status,
       message: mailStatus.message,
-      code: mailStatus.code
+      code: mailStatus.code,
     };
   }
 
-  async login(req){
+  async login(req) {
     // Login as guest
     const { email, password } = req.body;
-  
+
     let user = await User.findOne({ email });
-  
+
     const setFails = async (user, val) => {
       user.failedAttempts.count = val;
       user.failedAttempts.lastAttempt = Date.now();
@@ -65,40 +64,42 @@ class UserService{
     //     user = await setFails(user, 0);
     //   }
     // }
-  
+
     // check if user exists in DB or if password provided by user doesn't match user password in DB
     if (!user || !(await user.matchPasswords(password))) {
       // await setFails(user, user.failedAttempts.count + 1);
-      throw new CustomError('Invalid email or password', 401);
-    }
-  
-  
-    if(user.active === 0){
-      throw new CustomError('This account has been deactivated. Contact an admin', 401);
-    }
-    
-    // user = await setFails(user, 0);
-    user = user.toJSON();
-  
-    // check if user has unverified email
-    if (!user.isEmailVerified) {
-      throw new CustomError('Please verify your email to proceed', 401);
+      throw new CustomError("Invalid email or password", 401);
     }
 
-    if(user.twoFactorAuth.is2FA === false) {
+    if (user.active === 0) {
+      throw new CustomError(
+        "This account has been deactivated. Contact an admin",
+        401
+      );
+    }
+
+    // user = await setFails(user, 0);
+    user = user.toJSON();
+
+    // check if user has unverified email
+    if (!user.isEmailVerified) {
+      throw new CustomError("Please verify your email to proceed", 401);
+    }
+
+    if (user.twoFactorAuth.is2FA === false) {
       SessionMgt.login(req, user);
       return {
-        msg: 'Your account is not two factor authenticated',
-        data: user
+        msg: "Your account is not two factor authenticated",
+        data: user,
       };
     }
 
-    if(user.twoFactorAuth.status === 'approved') {
+    if (user.twoFactorAuth.status === "approved") {
       SessionMgt.login(req, user);
       return {
-        msg: 'Your account is protected with 2FA',
+        msg: "Your account is protected with 2FA",
         // data: user
-        data: user.toJSON().id
+        data: user.toJSON().id,
       };
     }
 
@@ -107,18 +108,16 @@ class UserService{
     // console.log(user)
 
     try {
-      if(user.twoFactorAuth.is2FA === true) {
-        const data = await client
-          .verify
+      if (user.twoFactorAuth.is2FA === true) {
+        const data = await client.verify
           .services(SERVICE_ID)
-          .verifications
-          .create({
+          .verifications.create({
             to: userNumber,
-            channel: 'sms'
+            channel: "sms",
           });
 
         let user2FA = await User.findOne({ email });
-  
+
         const set2FA = async (user, val) => {
           user.twoFactorAuth.is2FA = true;
           user.twoFactorAuth.status = val;
@@ -133,7 +132,7 @@ class UserService{
         return {
           user: user,
         };
-      } 
+      }
       // else {
       //   SessionMgt.login(req, user);
       //   return {
@@ -141,17 +140,16 @@ class UserService{
       //     user: user
       //   }
       // }
-    } catch(err) {
+    } catch (err) {
       if (err.status === 429 && err.code === 20492) {
         return {
-          data: 'Too many request'
+          data: "Too many request",
         };
       }
-    } 
+    }
   } //end login
 
   async otpVerify(req) {
-
     // const user2FA = req.session.user;
 
     const { code, userId } = req.query;
@@ -161,22 +159,27 @@ class UserService{
 
     let user = await User.findOne({ email });
 
-    if(user2FA.twoFactorAuth.status === 'approved' && user.twoFactorAuth.status === 'approved') {
+    if (
+      user2FA.twoFactorAuth.status === "approved" &&
+      user.twoFactorAuth.status === "approved"
+    ) {
       return {
-        msg: 'Your account is two factor authenticated',
-        data: user
+        msg: "Your account is two factor authenticated",
+        data: user,
       };
     }
 
-    try{
-      if(user2FA.twoFactorAuth.is2FA && user2FA.twoFactorAuth.status === 'pending' && code.length === 6) {
-        const data = await client
-          .verify
+    try {
+      if (
+        user2FA.twoFactorAuth.is2FA &&
+        user2FA.twoFactorAuth.status === "pending" &&
+        code.length === 6
+      ) {
+        const data = await client.verify
           .services(SERVICE_ID)
-          .verificationChecks
-          .create({
+          .verificationChecks.create({
             to: phone,
-            code: code
+            code: code,
           });
 
         let user = await User.findOne({ email });
@@ -190,20 +193,19 @@ class UserService{
         user2FA.twoFactorAuth.status = data.status;
         user = user.toJSON();
         return {
-          message: 'OTP successfully verified',
-          verify: data
+          message: "OTP successfully verified",
+          verify: data,
         };
-      } 
+      }
       return {
-        data: data.valid
+        data: data.valid,
       };
-    
     } catch (err) {
-      if(err.status === 404 && err.code === 20404) {
+      if (err.status === 404 && err.code === 20404) {
         return {
-          data: 'Invalid code/code expired'
+          data: "Invalid code/code expired",
         };
-      } 
+      }
     }
   }
 
@@ -214,8 +216,8 @@ class UserService{
     // const email = user.email;
 
     // let findUser = await User.findOne({ email });
-    try{
-      if(findUser.twoFactorAuth.is2FA === false) {
+    try {
+      if (findUser.twoFactorAuth.is2FA === false) {
         const enable2FA = async (user, val) => {
           user.twoFactorAuth.is2FA = val;
           return user.save();
@@ -225,18 +227,17 @@ class UserService{
         user.twoFactorAuth.is2FA = true;
         findUser = findUser.toJSON();
         return {
-          message: '2FA just enabled, now you can receive OTP and verify it',
-          data: findUser
+          message: "2FA just enabled, now you can receive OTP and verify it",
+          data: findUser,
         };
-      } 
+      }
       return {
-        message: '2FA is enabled, your account is protected',
-        data: findUser
+        message: "2FA is enabled, your account is protected",
+        data: findUser,
       };
-    
     } catch (err) {
       return {
-        message: 'something wrong' + err
+        message: "something wrong" + err,
       };
     }
   }
@@ -244,43 +245,119 @@ class UserService{
   async activeUser(req) {
     const active = req.session.user;
     console.log(active);
-    try{
-      if(!active) {
+    try {
+      if (!active) {
         return {
-          data: 'Please Login before you do that'
-        }; 
-      }
-      if(active.twoFactorAuth.is2FA && active.twoFactorAuth.status === 'pending') {
-        return {
-          msg: 'Please verify your 2FA Auth',
-          data: active
+          data: "Please Login before you do that",
         };
       }
-      if(active.twoFactorAuth.is2FA && active.twoFactorAuth.status === 'approved') {
+      if (
+        active.twoFactorAuth.is2FA &&
+        active.twoFactorAuth.status === "pending"
+      ) {
         return {
-          msg: 'Your account is highly protected with 2FA',
-          data: active
+          msg: "Please verify your 2FA Auth",
+          data: active,
         };
       }
-      if(!active.twoFactorAuth.is2FA && active.twoFactorAuth.status === null) {
+      if (
+        active.twoFactorAuth.is2FA &&
+        active.twoFactorAuth.status === "approved"
+      ) {
         return {
-          msg: 'Here your credential but I highly recommend you enable 2FA auth',
-          data: active
+          msg: "Your account is highly protected with 2FA",
+          data: active,
         };
       }
-    } catch(err) {
+      if (!active.twoFactorAuth.is2FA && active.twoFactorAuth.status === null) {
+        return {
+          msg:
+            "Here your credential but I highly recommend you enable 2FA auth",
+          data: active,
+        };
+      }
+    } catch (err) {
       return {
-        data: err
+        data: err,
       };
     }
   }
 
-  async forgotPassword(req){    
-    
+  async updateAuthProviders(req) {
+    const active = req.session.user;
+
+    try {
+      if (!active) {
+        return {
+          data: "Please Login before you do that",
+        };
+      }
+
+      if (
+        active.twoFactorAuth.is2FA &&
+        active.twoFactorAuth.status === "pending"
+      ) {
+        return {
+          msg: "Please verify your 2FA Auth",
+          data: active,
+        };
+      }
+
+      const user = await User.findById(active.id);
+      active = user.toJSON();
+
+      const update = {
+        twitterEnabled:
+          req.body.twitterEnabled !== undefined
+            ? req.body.twitterEnabled
+            : active.twitterEnabled,
+        facebookEnabled:
+          req.body.facebookEnabled !== undefined
+            ? req.body.facebookEnabled
+            : active.facebookEnabled,
+        githubEnabled:
+          req.body.githubEnabled !== undefined
+            ? req.body.githubEnabled
+            : active.githubEnabled,
+        googleEnabled:
+          req.body.googleEnabled !== undefined
+            ? req.body.googleEnabled
+            : active.googleEnabled,
+      };
+
+      await User.findByIdAndUpdate(active.id, update);
+
+      await SessionMgt.login(req, active);
+
+      if (
+        active.twoFactorAuth.is2FA &&
+        active.twoFactorAuth.status === "approved"
+      ) {
+        return {
+          msg: "Your account is highly protected with 2FA",
+          data: active,
+        };
+      }
+
+      if (!active.twoFactorAuth.is2FA && active.twoFactorAuth.status === null) {
+        return {
+          msg:
+            "Here your updated authentication providers but I highly recommend you enable 2FA auth",
+          data: active,
+        };
+      }
+    } catch (err) {
+      return {
+        data: err,
+      };
+    }
+  } //end upadteAuthProviders
+
+  async forgotPassword(req) {
     const { email } = req.body;
     // const buffer = crypto.randomBytes(32);
     // const token = buffer.toString();
-    
+
     const token = RandomString.generate(64);
     const expirationTime = Date.now() + 3600000; // 1 hour
     const user = await User.findOneAndUpdate(
@@ -303,21 +380,20 @@ class UserService{
         404
       );
     }
-    
+
     const resetUrl = `http:\/\/${req.headers.host}\/api\/user\/password\/${token}`;
     sendForgotPasswordMail(user.email, user.username, resetUrl);
 
     return {
       url: resetUrl,
-      user: user
+      user: user,
     };
-
   } //end forgotPass
 
-  async resetPassword(req){
+  async resetPassword(req) {
     const { token } = req.params;
     const { password } = req.body;
-    
+
     const user = await User.findOneAndUpdate(
       {
         resetPasswordToken: token,
@@ -334,20 +410,19 @@ class UserService{
         new: true,
       }
     );
-  
+
     if (!user) {
       throw new CustomError(
-        'Password reset token is invalid or has expired.',
+        "Password reset token is invalid or has expired.",
         422
       );
     }
-  
-    await user.save();
-  
-    return {
-      user: user
-    };
 
+    await user.save();
+
+    return {
+      user: user,
+    };
   }
 }
 

--- a/src/swagger/openApiDocumentation.js
+++ b/src/swagger/openApiDocumentation.js
@@ -1,66 +1,62 @@
 const openApiDocumentation = {
-  swagger: '3.0',
-  openapi: '3.0.1',
+  openapi: "3.0.1",
   info: {
-    title: 'HNGI Authetication Micro-Service',
-    description: 'A Dockerized Microservice for Authentication',
+    title: "HNGI Authetication Micro-Service",
+    description: "A Dockerized Microservice for Authentication",
     contact: {
-      name: 'HNGI',
+      name: "HNGI",
     },
   },
   server: [
     {
-      url: 'http:localhost:5000',
-      description: 'Local Server',
+      url: "http:localhost:5000",
+      description: "Local Server",
     },
     {
-      url: 'https://auth-microapi.herokuapp.com',
-      description: 'Staging Server',
+      url: "https://auth-microapi.herokuapp.com",
+      description: "Staging Server",
     },
     {
-      url: 'https://auth.microapi.dev',
-      description: 'Staging Server',
-    }
+      url: "https://auth.microapi.dev",
+      description: "Staging Server",
+    },
   ],
   tags: [
     {
-      name: 'Authentication',
+      name: "Authentication",
     },
   ],
-  schemes: [
-    'HTTP',
-    'HTTPS'
-  ],
+  schemes: ["HTTP", "HTTPS"],
   security: {
     bearerAuth: {},
   },
   //input api paths in here
   paths: {
-    '/api/user/active': {
+    "/api/user/active": {
       get: {
-        tags: ['Active user'],
-        description: 'Registers admin',
-        operationId: 'register',
-        security: [ {bearerAuth: {}}],
+        tags: ["Active user"],
+        description: "Registers admin",
+        operationId: "register",
+        security: [{ bearerAuth: {} }],
         requestBody: {},
         parameters: [],
         responses: {
-          '200': {
-            description: 'Success',
+          "200": {
+            description: "Success",
             content: {
-              'application/json': {
+              "application/json": {
                 schema: {
-                  $ref: '#/components/schemas/Response',
+                  $ref: "#/components/schemas/Response",
                 },
               },
             },
           },
-          '400': {
-            description: 'Bad Request',
+          "400": {
+            description: "Bad Request",
             content: {
-              'application/json': {
+              "application/json": {
                 schema: {
-                  $ref: '#/components/schemas/Response',
+                  $ref: "#/components/schemas/Response",
                 },
               },
             },
@@ -68,17 +64,17 @@ const openApiDocumentation = {
         },
       },
     },
-    '/api/admin/register': {
+    "/api/admin/register": {
       post: {
-        tags: ['Register Admin'],
-        description: 'Registers admin',
-        operationId: 'register',
-        security: [ {bearerAuth: {}}],
+        tags: ["Register Admin"],
+        description: "Registers admin",
+        operationId: "register",
+        security: [{ bearerAuth: {} }],
         requestBody: {
           content: {
-            'application/json': {
+            "application/json": {
               schema: {
-                $ref: '#/components/schemas/User',
+                $ref: "#/components/schemas/User",
               },
             },
           },
@@ -86,22 +82,22 @@ const openApiDocumentation = {
         },
         parameters: [],
         responses: {
-          '200': {
-            description: 'Success',
+          "200": {
+            description: "Success",
             content: {
-              'application/json': {
+              "application/json": {
                 schema: {
-                  $ref: '#/components/schemas/Response',
+                  $ref: "#/components/schemas/Response",
                 },
               },
             },
           },
-          '400': {
-            description: 'Bad Request',
+          "400": {
+            description: "Bad Request",
             content: {
-              'application/json': {
+              "application/json": {
                 schema: {
-                  $ref: '#/components/schemas/Response',
+                  $ref: "#/components/schemas/Response",
                 },
               },
             },
@@ -109,99 +105,169 @@ const openApiDocumentation = {
         },
       },
     },
-    '/api/admin/getkey': {
-      post: {
-        tags: ['Get APIKEY'],
-        description: 'login user',
-        operationId: 'getkey',
-        security: [ {bearerAuth: {}}],
-        requestBody: {
-          content: {
-            'application/json': {
-              schema: {
-                $ref: '#/components/schemas/Login',
-              },
-            },
-          },
-          required: true,
-        },
+    "/api/admin/settings": {
+      get: {
+        tags: ["Get Admin Settings"],
+        description: "Returns the settings of an admin",
+        operationId: "settings",
+        security: [{ bearerAuth: {} }],
         parameters: [],
         responses: {
-          '200': {
-            description: 'Success',
+          "200": {
+            description: "Success",
             content: {
-              'application/json': {
+              "application/json": {
                 schema: {
-                  $ref: '#/components/schemas/Response',
+                  $ref: "#/components/schemas/Response",
                 },
               },
             },
           },
-          '400': {
-            description: 'Bad Request',
+          "400": {
+            description: "Bad Request",
             content: {
-              'application/json': {
+              "application/json": {
                 schema: {
-                  $ref: '#/components/schemas/Response',
-                },
-              },
-            },
-          },
-        },
-      },
-    },
-    '/api/admin/reset-password': {
-      post: {
-        tags: ['Admin reset password'],
-        description: 'Get new password in case of forgotten password',
-        operationId: 'reset-password',
-        security: [ {bearerAuth: {}}],
-        requestBody: {
-          content: {
-            'application/json': {
-              schema: {
-                $ref: '#/components/schemas/Forgot',
-              },
-            },
-          },
-          required: true,
-        },
-        parameters: [],
-        responses: {
-          '200': {
-            description: 'Success',
-            content: {
-              'application/json': {
-                schema: {
-                  $ref: '#/components/schemas/Response',
-                },
-              },
-            },
-          },
-          '400': {
-            description: 'Bad Request',
-            content: {
-              'application/json': {
-                schema: {
-                  $ref: '#/components/schemas/Response',
+                  $ref: "#/components/schemas/Response",
                 },
               },
             },
           },
         },
       },
-    },
-    '/api/admin/reset-password/{token}': {
       patch: {
-        tags: ['Admin chanage password'],
-        description: 'Get new password in case of forgotten password',
-        operationId: 'reset-password',
-        security: [ {bearerAuth: {}}],
+        tags: ["Update Admin Settings"],
+        description: "Updates the settings of an admin",
+        operationId: "settings",
+        security: [{ bearerAuth: {} }],
         requestBody: {
           content: {
-            'application/json': {
+            "application/json": {
               schema: {
-                $ref: '#/components/schemas/Reset',
+                $ref: "#/components/schemas/UpdateSettings",
+              },
+            },
+          },
+          required: true,
+        },
+        parameters: [],
+        responses: {
+          "200": {
+            description: "Success",
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/Response",
+                },
+              },
+            },
+          },
+          "400": {
+            description: "Bad Request",
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/Response",
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    "/api/admin/getkey": {
+      post: {
+        tags: ["Get APIKEY"],
+        description: "login user",
+        operationId: "getkey",
+        security: [{ bearerAuth: {} }],
+        requestBody: {
+          content: {
+            "application/json": {
+              schema: {
+                $ref: "#/components/schemas/Login",
+              },
+            },
+          },
+          required: true,
+        },
+        parameters: [],
+        responses: {
+          "200": {
+            description: "Success",
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/Response",
+                },
+              },
+            },
+          },
+          "400": {
+            description: "Bad Request",
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/Response",
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    "/api/admin/reset-password": {
+      post: {
+        tags: ["Admin reset password"],
+        description: "Get new password in case of forgotten password",
+        operationId: "reset-password",
+        security: [{ bearerAuth: {} }],
+        requestBody: {
+          content: {
+            "application/json": {
+              schema: {
+                $ref: "#/components/schemas/Forgot",
+              },
+            },
+          },
+          required: true,
+        },
+        parameters: [],
+        responses: {
+          "200": {
+            description: "Success",
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/Response",
+                },
+              },
+            },
+          },
+          "400": {
+            description: "Bad Request",
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/Response",
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    "/api/admin/reset-password/{token}": {
+      patch: {
+        tags: ["Admin chanage password"],
+        description: "Get new password in case of forgotten password",
+        operationId: "reset-password",
+        security: [{ bearerAuth: {} }],
+        requestBody: {
+          content: {
+            "application/json": {
+              schema: {
+                $ref: "#/components/schemas/Reset",
               },
             },
           },
@@ -209,31 +275,31 @@ const openApiDocumentation = {
         },
         parameters: [
           {
-            name: 'token',
-            in: 'query',
+            name: "token",
+            in: "query",
             schema: {
-              type: 'string',
+              type: "string",
             },
             required: true,
           },
         ],
         responses: {
-          '200': {
-            description: 'Success',
+          "200": {
+            description: "Success",
             content: {
-              'application/json': {
+              "application/json": {
                 schema: {
-                  $ref: '#/components/schemas/Response',
+                  $ref: "#/components/schemas/Response",
                 },
               },
             },
           },
-          '400': {
-            description: 'Bad Request',
+          "400": {
+            description: "Bad Request",
             content: {
-              'application/json': {
+              "application/json": {
                 schema: {
-                  $ref: '#/components/schemas/Response',
+                  $ref: "#/components/schemas/Response",
                 },
               },
             },
@@ -241,17 +307,17 @@ const openApiDocumentation = {
         },
       },
     },
-    '/api/user/register': {
+    "/api/user/register": {
       post: {
-        tags: ['Register User'],
-        description: 'Registers user',
-        operationId: 'registeruser',
-        security: [ {bearerAuth: {}}],
+        tags: ["Register User"],
+        description: "Registers user",
+        operationId: "registeruser",
+        security: [{ bearerAuth: {} }],
         requestBody: {
           content: {
-            'application/json': {
+            "application/json": {
               schema: {
-                $ref: '#/components/schemas/User',
+                $ref: "#/components/schemas/User",
               },
             },
           },
@@ -259,22 +325,22 @@ const openApiDocumentation = {
         },
         parameters: [],
         responses: {
-          '200': {
-            description: 'Success',
+          "200": {
+            description: "Success",
             content: {
-              'application/json': {
+              "application/json": {
                 schema: {
-                  $ref: '#/components/schemas/Response',
+                  $ref: "#/components/schemas/Response",
                 },
               },
             },
           },
-          '400': {
-            description: 'Bad Request',
+          "400": {
+            description: "Bad Request",
             content: {
-              'application/json': {
+              "application/json": {
                 schema: {
-                  $ref: '#/components/schemas/Response',
+                  $ref: "#/components/schemas/Response",
                 },
               },
             },
@@ -282,30 +348,30 @@ const openApiDocumentation = {
         },
       },
     },
-    '/api/user/email-verification/resend': {
+    "/api/user/email-verification/resend": {
       get: {
-        tags: ['Email resend verification'],
-        description: 'email resend varification',
-        operationId: 'verifyuseremail',
-        security: [ {bearerAuth: {}}],
+        tags: ["Email resend verification"],
+        description: "email resend varification",
+        operationId: "verifyuseremail",
+        security: [{ bearerAuth: {} }],
         parameters: [],
         responses: {
-          '200': {
-            description: 'Success',
+          "200": {
+            description: "Success",
             content: {
-              'application/json': {
+              "application/json": {
                 schema: {
-                  $ref: '#/components/schemas/Response',
+                  $ref: "#/components/schemas/Response",
                 },
               },
             },
           },
-          '400': {
-            description: 'Bad Request',
+          "400": {
+            description: "Bad Request",
             content: {
-              'application/json': {
+              "application/json": {
                 schema: {
-                  $ref: '#/components/schemas/Response',
+                  $ref: "#/components/schemas/Response",
                 },
               },
             },
@@ -313,30 +379,30 @@ const openApiDocumentation = {
         },
       },
     },
-    '/api/user/enable': {
+    "/api/user/enable": {
       get: {
-        tags: ['enable 2FA'],
-        description: 'enable 2FA',
-        operationId: 'enable2FA',
-        security: [ {bearerAuth: {}}],
+        tags: ["enable 2FA"],
+        description: "enable 2FA",
+        operationId: "enable2FA",
+        security: [{ bearerAuth: {} }],
         parameters: [],
         responses: {
-          '200': {
-            description: 'Success',
+          "200": {
+            description: "Success",
             content: {
-              'application/json': {
+              "application/json": {
                 schema: {
-                  $ref: '#/components/schemas/Response',
+                  $ref: "#/components/schemas/Response",
                 },
               },
             },
           },
-          '400': {
-            description: 'Bad Request',
+          "400": {
+            description: "Bad Request",
             content: {
-              'application/json': {
+              "application/json": {
                 schema: {
-                  $ref: '#/components/schemas/Response',
+                  $ref: "#/components/schemas/Response",
                 },
               },
             },
@@ -344,17 +410,17 @@ const openApiDocumentation = {
         },
       },
     },
-    '/api/user/login': {
+    "/api/user/login": {
       post: {
-        tags: ['Login User'],
-        description: 'login user',
-        operationId: 'loginuser',
-        security: [ {bearerAuth: {}}],
+        tags: ["Login User"],
+        description: "login user",
+        operationId: "loginuser",
+        security: [{ bearerAuth: {} }],
         requestBody: {
           content: {
-            'application/json': {
+            "application/json": {
               schema: {
-                $ref: '#/components/schemas/Login',
+                $ref: "#/components/schemas/Login",
               },
             },
           },
@@ -362,22 +428,22 @@ const openApiDocumentation = {
         },
         parameters: [],
         responses: {
-          '200': {
-            description: 'Success',
+          "200": {
+            description: "Success",
             content: {
-              'application/json': {
+              "application/json": {
                 schema: {
-                  $ref: '#/components/schemas/Response',
+                  $ref: "#/components/schemas/Response",
                 },
               },
             },
           },
-          '400': {
-            description: 'Bad Request',
+          "400": {
+            description: "Bad Request",
             content: {
-              'application/json': {
+              "application/json": {
                 schema: {
-                  $ref: '#/components/schemas/Response',
+                  $ref: "#/components/schemas/Response",
                 },
               },
             },
@@ -385,31 +451,31 @@ const openApiDocumentation = {
         },
       },
     },
-    '/api/user/verify': {
+    "/api/user/verify": {
       get: {
-        tags: ['verify OTP'],
-        description: 'verify OTP',
-        operationId: 'verifyOTP',
-        security: [ {bearerAuth: {}}],
+        tags: ["verify OTP"],
+        description: "verify OTP",
+        operationId: "verifyOTP",
+        security: [{ bearerAuth: {} }],
         requestBody: {},
         parameters: [],
         responses: {
-          '200': {
-            description: 'Success',
+          "200": {
+            description: "Success",
             content: {
-              'application/json': {
+              "application/json": {
                 schema: {
-                  $ref: '#/components/schemas/Response',
+                  $ref: "#/components/schemas/Response",
                 },
               },
             },
           },
-          '400': {
-            description: 'Bad Request',
+          "400": {
+            description: "Bad Request",
             content: {
-              'application/json': {
+              "application/json": {
                 schema: {
-                  $ref: '#/components/schemas/Response',
+                  $ref: "#/components/schemas/Response",
                 },
               },
             },
@@ -417,17 +483,17 @@ const openApiDocumentation = {
         },
       },
     },
-    '/api/user/password/reset': {
+    "/api/user/password/reset": {
       post: {
-        tags: ['forgot-password'],
-        description: 'Enter your email to reset your password',
-        operationId: 'forgot-password',
-        security: [ {bearerAuth: {}}],
+        tags: ["forgot-password"],
+        description: "Enter your email to reset your password",
+        operationId: "forgot-password",
+        security: [{ bearerAuth: {} }],
         requestBody: {
           content: {
-            'application/json': {
+            "application/json": {
               schema: {
-                $ref: '#/components/schemas/Forgot',
+                $ref: "#/components/schemas/Forgot",
               },
             },
           },
@@ -435,22 +501,22 @@ const openApiDocumentation = {
         },
         parameters: [],
         responses: {
-          '200': {
-            description: 'Success',
+          "200": {
+            description: "Success",
             content: {
-              'application/json': {
+              "application/json": {
                 schema: {
-                  $ref: '#/components/schemas/Response',
+                  $ref: "#/components/schemas/Response",
                 },
               },
             },
           },
-          '400': {
-            description: 'Bad Request',
+          "400": {
+            description: "Bad Request",
             content: {
-              'application/json': {
+              "application/json": {
                 schema: {
-                  $ref: '#/components/schemas/Response',
+                  $ref: "#/components/schemas/Response",
                 },
               },
             },
@@ -458,17 +524,17 @@ const openApiDocumentation = {
         },
       },
     },
-    '/api/user/password/{token}': {
+    "/api/user/password/{token}": {
       patch: {
-        tags: ['reset-password'],
-        description: 'Enter your new password to reset password',
-        operationId: 'reset-password',
-        security: [ {bearerAuth: {}}],
+        tags: ["reset-password"],
+        description: "Enter your new password to reset password",
+        operationId: "reset-password",
+        security: [{ bearerAuth: {} }],
         requestBody: {
           content: {
-            'application/json': {
+            "application/json": {
               schema: {
-                $ref: '#/components/schemas/Reset',
+                $ref: "#/components/schemas/Reset",
               },
             },
           },
@@ -476,61 +542,31 @@ const openApiDocumentation = {
         },
         parameters: [
           {
-            name: 'token',
-            in: 'query',
+            name: "token",
+            in: "query",
             schema: {
-              type: 'string',
+              type: "string",
             },
             required: true,
           },
         ],
         responses: {
-          '200': {
-            description: 'Success',
+          "200": {
+            description: "Success",
             content: {
-              'application/json': {
+              "application/json": {
                 schema: {
-                  $ref: '#/components/schemas/Response',
+                  $ref: "#/components/schemas/Response",
                 },
               },
             },
           },
-          '400': {
-            description: 'Bad Request',
+          "400": {
+            description: "Bad Request",
             content: {
-              'application/json': {
+              "application/json": {
                 schema: {
-                  $ref: '#/components/schemas/Response',
-                },
-              },
-            },
-          },
-        },
-      },
-    },
-    '/api/auth/facebook': {
-      get: {
-        tags: ['Facebook Auth'],
-        description: 'Creates or logs in User through Facebook',
-        operationId: 'FacebookAuth',
-        parameters: [],
-        responses: {
-          '200': {
-            description: 'Success',
-            content: {
-              'application/json': {
-                schema: {
-                  $ref: '#/components/schemas/Response',
-                },
-              },
-            },
-          },
-          '400': {
-            description: 'Bad Request',
-            content: {
-              'application/json': {
-                schema: {
-                  $ref: '#/components/schemas/Response',
+                  $ref: "#/components/schemas/Response",
                 },
               },
             },
@@ -538,29 +574,29 @@ const openApiDocumentation = {
         },
       },
     },
-    '/api/auth/google': {
+    "/api/auth/facebook": {
       get: {
-        tags: ['Google Auth'],
-        description: 'Creates or logs in User through Google',
-        operationId: 'googleauth',
+        tags: ["Facebook Auth"],
+        description: "Creates or logs in User through Facebook",
+        operationId: "FacebookAuth",
         parameters: [],
         responses: {
-          '200': {
-            description: 'Success',
+          "200": {
+            description: "Success",
             content: {
-              'application/json': {
+              "application/json": {
                 schema: {
-                  $ref: '#/components/schemas/Response',
+                  $ref: "#/components/schemas/Response",
                 },
               },
             },
           },
-          '400': {
-            description: 'Bad Request',
+          "400": {
+            description: "Bad Request",
             content: {
-              'application/json': {
+              "application/json": {
                 schema: {
-                  $ref: '#/components/schemas/Response',
+                  $ref: "#/components/schemas/Response",
                 },
               },
             },
@@ -568,29 +604,29 @@ const openApiDocumentation = {
         },
       },
     },
-    '/api/auth/twitter': {
+    "/api/auth/google": {
       get: {
-        tags: ['Twitter Auth'],
-        description: 'Creates or logs in User through Twitter',
-        operationId: 'twitterauth',
+        tags: ["Google Auth"],
+        description: "Creates or logs in User through Google",
+        operationId: "googleauth",
         parameters: [],
         responses: {
-          '200': {
-            description: 'Success',
+          "200": {
+            description: "Success",
             content: {
-              'application/json': {
+              "application/json": {
                 schema: {
-                  $ref: '#/components/schemas/Response',
+                  $ref: "#/components/schemas/Response",
                 },
               },
             },
           },
-          '400': {
-            description: 'Bad Request',
+          "400": {
+            description: "Bad Request",
             content: {
-              'application/json': {
+              "application/json": {
                 schema: {
-                  $ref: '#/components/schemas/Response',
+                  $ref: "#/components/schemas/Response",
                 },
               },
             },
@@ -598,30 +634,29 @@ const openApiDocumentation = {
         },
       },
     },
-    '/api/auth/github': {
+    "/api/auth/twitter": {
       get: {
-        tags: ['Github auth'],
-        description: 'github auth',
-        operationId: 'github auth',
-        security: [ {bearerAuth: {}}],
+        tags: ["Twitter Auth"],
+        description: "Creates or logs in User through Twitter",
+        operationId: "twitterauth",
         parameters: [],
         responses: {
-          '200': {
-            description: 'Success',
+          "200": {
+            description: "Success",
             content: {
-              'application/json': {
+              "application/json": {
                 schema: {
-                  $ref: '#/components/schemas/Response',
+                  $ref: "#/components/schemas/Response",
                 },
               },
             },
           },
-          '400': {
-            description: 'Bad Request',
+          "400": {
+            description: "Bad Request",
             content: {
-              'application/json': {
+              "application/json": {
                 schema: {
-                  $ref: '#/components/schemas/Response',
+                  $ref: "#/components/schemas/Response",
                 },
               },
             },
@@ -629,29 +664,60 @@ const openApiDocumentation = {
         },
       },
     },
-    '/api/user/logout': {
+    "/api/auth/github": {
       get: {
-        tags: ['Logout user '],
-        description: 'logout user',
-        operationId: 'logoutuser',
+        tags: ["Github auth"],
+        description: "github auth",
+        operationId: "github auth",
+        security: [{ bearerAuth: {} }],
         parameters: [],
         responses: {
-          '200': {
-            description: 'Success',
+          "200": {
+            description: "Success",
             content: {
-              'application/json': {
+              "application/json": {
                 schema: {
-                  $ref: '#/components/schemas/Response',
+                  $ref: "#/components/schemas/Response",
                 },
               },
             },
           },
-          '400': {
-            description: 'Bad Request',
+          "400": {
+            description: "Bad Request",
             content: {
-              'application/json': {
+              "application/json": {
                 schema: {
-                  $ref: '#/components/schemas/Response',
+                  $ref: "#/components/schemas/Response",
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    "/api/user/logout": {
+      get: {
+        tags: ["Logout user "],
+        description: "logout user",
+        operationId: "logoutuser",
+        parameters: [],
+        responses: {
+          "200": {
+            description: "Success",
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/Response",
+                },
+              },
+            },
+          },
+          "400": {
+            description: "Bad Request",
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/Response",
                 },
               },
             },
@@ -663,88 +729,141 @@ const openApiDocumentation = {
   components: {
     schemas: {
       User: {
-        type: 'object',
+        type: "object",
         properties: {
           username: {
-            type: 'string',
-            description: 'User\'s Name',
+            type: "string",
+            description: "User's Name",
           },
           email: {
-            type: 'string',
-            description: 'User Email Address',
+            type: "string",
+            description: "User Email Address",
           },
           password: {
-            type: 'string',
-            description: 'User Password',
+            type: "string",
+            description: "User Password",
           },
           phone_number: {
-            type: 'string',
-            Sdescription: 'User phone number',
+            type: "string",
+            Sdescription: "User phone number",
           },
         },
       },
       Login: {
-        type: 'object',
+        type: "object",
         properties: {
           email: {
-            type: 'string',
-            description: 'User Email Address',
+            type: "string",
+            description: "User Email Address",
           },
           password: {
-            type: 'string',
-            description: 'User Password',
+            type: "string",
+            description: "User Password",
+          },
+        },
+      },
+      UpdateSettings: {
+        type: "object",
+        properties: {
+          email: {
+            type: "string",
+            description: "User Email Address",
+          },
+          facebookAuthProvider: {
+            type: "object",
+            properties: {
+              appID: {
+                type: "string",
+              },
+              appSecret: {
+                type: "string",
+              },
+            },
+          },
+          twitterAuthProvider: {
+            type: "object",
+            properties: {
+              key: {
+                type: "string",
+              },
+              secret: {
+                type: "string",
+              },
+            },
+          },
+          githubAuthProvider: {
+            type: "object",
+            properties: {
+              clientID: {
+                type: "string",
+              },
+              clientSecret: {
+                type: "string",
+              },
+            },
+          },
+          googleAuthProvider: {
+            type: "object",
+            properties: {
+              clientID: {
+                type: "string",
+              },
+              clientSecret: {
+                type: "string",
+              },
+            },
           },
         },
       },
       Forgot: {
-        type: 'object',
+        type: "object",
         properties: {
           email: {
-            type: 'string',
-            description: 'User Email Address',
+            type: "string",
+            description: "User Email Address",
           },
         },
       },
       Reset: {
-        type: 'object',
+        type: "object",
         properties: {
           password: {
-            type: 'string',
-            description: 'User Password',
+            type: "string",
+            description: "User Password",
           },
           password_comfirm: {
-            type: 'string',
-            description: 'New password',
+            type: "string",
+            description: "New password",
           },
         },
       },
       Response: {
-        type: 'object',
+        type: "object",
         properties: {
           status: {
-            type: 'string',
+            type: "string",
           },
           message: {
-            type: 'string',
+            type: "string",
           },
           data: {
-            type: 'object',
+            type: "object",
           },
         },
       },
     },
     responses: {
       UnauthorizedError: {
-        description: 'Access token is missing or invalid'
-      }
+        description: "Access token is missing or invalid",
+      },
     },
     securitySchemes: {
       bearerAuth: {
-        type: 'http',
-        scheme: 'bearer',
-        bearerFormat: 'JWT',
-        name: 'Authorization',
-        in: 'header',
+        type: "http",
+        scheme: "bearer",
+        bearerFormat: "JWT",
+        name: "Authorization",
+        in: "header",
       },
     },
   },

--- a/src/swagger/openApiDocumentation.js
+++ b/src/swagger/openApiDocumentation.js
@@ -202,7 +202,6 @@ const openApiDocumentation = {
         tags: [ADMINISTRATOR_TAG],
         description: "Get new password in case of forgotten password",
         operationId: "reset-password",
-        security: apiKeySecurity,
         requestBody: {
           content: {
             "application/json": {
@@ -243,7 +242,6 @@ const openApiDocumentation = {
         tags: [ADMINISTRATOR_TAG],
         description: "Get new password in case of forgotten password",
         operationId: "reset-password",
-        security: apiKeySecurity,
         requestBody: {
           content: {
             "application/json": {

--- a/src/swagger/openApiDocumentation.js
+++ b/src/swagger/openApiDocumentation.js
@@ -574,7 +574,7 @@ const openApiDocumentation = {
         },
       },
     },
-    "/api/auth/facebook": {
+    "/api/facebook": {
       get: {
         tags: ["Facebook Auth"],
         description: "Creates or logs in User through Facebook",
@@ -604,7 +604,7 @@ const openApiDocumentation = {
         },
       },
     },
-    "/api/auth/google": {
+    "/api/google": {
       get: {
         tags: ["Google Auth"],
         description: "Creates or logs in User through Google",
@@ -634,7 +634,7 @@ const openApiDocumentation = {
         },
       },
     },
-    "/api/auth/twitter": {
+    "/api/twitter": {
       get: {
         tags: ["Twitter Auth"],
         description: "Creates or logs in User through Twitter",
@@ -664,7 +664,7 @@ const openApiDocumentation = {
         },
       },
     },
-    "/api/auth/github": {
+    "/api/github": {
       get: {
         tags: ["Github auth"],
         description: "github auth",

--- a/src/swagger/openApiDocumentation.js
+++ b/src/swagger/openApiDocumentation.js
@@ -1,75 +1,57 @@
+// List of tags used by documentation.
+const ADMINISTRATOR_TAG = "Administrators";
+const USER_TAG = "Users";
+const AUTH_PROVIDER_TAG = "Authentication Providers";
+
+// Security schema.
+const apiKeySecurity = [{ Bearer: [] }];
+
 const openApiDocumentation = {
-  openapi: "3.0.1",
+  openapi: "3.0.21",
   info: {
+    version: "1.0.0",
     title: "HNGI Authetication Micro-Service",
     description: "A Dockerized Microservice for Authentication",
     contact: {
       name: "HNGI",
     },
   },
-  server: [
+  servers: [
     {
-      url: "http:localhost:5000",
-      description: "Local Server",
+      url: "https://auth-microapi.herokuapp.com/api",
+      description: "Staging Server (uses test data)",
     },
     {
-      url: "https://auth-microapi.herokuapp.com",
-      description: "Staging Server",
+      url: "https://auth.microapi.dev/api",
+      description: "Production Server (uses live data)",
     },
     {
-      url: "https://auth.microapi.dev",
-      description: "Staging Server",
+      url: "/api",
+      description: "Local Server (uses your data)",
     },
   ],
   tags: [
     {
-      name: "Authentication",
+      name: ADMINISTRATOR_TAG,
+      description: "Create and modify administrators.",
+    },
+    {
+      name: USER_TAG,
+      description: "Create and modify users.",
+    },
+    {
+      name: AUTH_PROVIDER_TAG,
+      description: "Create and modify users via the authentication providers.",
     },
   ],
   schemes: ["HTTP", "HTTPS"],
-  security: {
-    bearerAuth: {},
-  },
   //input api paths in here
   paths: {
-    "/api/user/active": {
-      get: {
-        tags: ["Active user"],
-        description: "Registers admin",
-        operationId: "register",
-        security: [{ bearerAuth: {} }],
-        requestBody: {},
-        parameters: [],
-        responses: {
-          "200": {
-            description: "Success",
-            content: {
-              "application/json": {
-                schema: {
-                  $ref: "#/components/schemas/Response",
-                },
-              },
-            },
-          },
-          "400": {
-            description: "Bad Request",
-            content: {
-              "application/json": {
-                schema: {
-                  $ref: "#/components/schemas/Response",
-                },
-              },
-            },
-          },
-        },
-      },
-    },
-    "/api/admin/register": {
+    "/admin/register": {
       post: {
-        tags: ["Register Admin"],
+        tags: [ADMINISTRATOR_TAG],
         description: "Registers admin",
         operationId: "register",
-        security: [{ bearerAuth: {} }],
         requestBody: {
           content: {
             "application/json": {
@@ -105,12 +87,52 @@ const openApiDocumentation = {
         },
       },
     },
-    "/api/admin/settings": {
+    "/admin/getkey": {
+      post: {
+        tags: [ADMINISTRATOR_TAG],
+        description: "login user",
+        operationId: "getkey",
+        requestBody: {
+          content: {
+            "application/json": {
+              schema: {
+                $ref: "#/components/schemas/Login",
+              },
+            },
+          },
+          required: true,
+        },
+        parameters: [],
+        responses: {
+          "200": {
+            description: "Success",
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/Response",
+                },
+              },
+            },
+          },
+          "400": {
+            description: "Bad Request",
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/Response",
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    "/admin/settings": {
       get: {
-        tags: ["Get Admin Settings"],
+        tags: [ADMINISTRATOR_TAG],
         description: "Returns the settings of an admin",
         operationId: "settings",
-        security: [{ bearerAuth: {} }],
+        security: apiKeySecurity,
         parameters: [],
         responses: {
           "200": {
@@ -136,10 +158,10 @@ const openApiDocumentation = {
         },
       },
       patch: {
-        tags: ["Update Admin Settings"],
+        tags: [ADMINISTRATOR_TAG],
         description: "Updates the settings of an admin",
         operationId: "settings",
-        security: [{ bearerAuth: {} }],
+        security: apiKeySecurity,
         requestBody: {
           content: {
             "application/json": {
@@ -175,53 +197,12 @@ const openApiDocumentation = {
         },
       },
     },
-    "/api/admin/getkey": {
+    "/admin/reset-password": {
       post: {
-        tags: ["Get APIKEY"],
-        description: "login user",
-        operationId: "getkey",
-        security: [{ bearerAuth: {} }],
-        requestBody: {
-          content: {
-            "application/json": {
-              schema: {
-                $ref: "#/components/schemas/Login",
-              },
-            },
-          },
-          required: true,
-        },
-        parameters: [],
-        responses: {
-          "200": {
-            description: "Success",
-            content: {
-              "application/json": {
-                schema: {
-                  $ref: "#/components/schemas/Response",
-                },
-              },
-            },
-          },
-          "400": {
-            description: "Bad Request",
-            content: {
-              "application/json": {
-                schema: {
-                  $ref: "#/components/schemas/Response",
-                },
-              },
-            },
-          },
-        },
-      },
-    },
-    "/api/admin/reset-password": {
-      post: {
-        tags: ["Admin reset password"],
+        tags: [ADMINISTRATOR_TAG],
         description: "Get new password in case of forgotten password",
         operationId: "reset-password",
-        security: [{ bearerAuth: {} }],
+        security: apiKeySecurity,
         requestBody: {
           content: {
             "application/json": {
@@ -257,12 +238,12 @@ const openApiDocumentation = {
         },
       },
     },
-    "/api/admin/reset-password/{token}": {
+    "/admin/reset-password/{token}": {
       patch: {
-        tags: ["Admin chanage password"],
+        tags: [ADMINISTRATOR_TAG],
         description: "Get new password in case of forgotten password",
         operationId: "reset-password",
-        security: [{ bearerAuth: {} }],
+        security: apiKeySecurity,
         requestBody: {
           content: {
             "application/json": {
@@ -307,12 +288,12 @@ const openApiDocumentation = {
         },
       },
     },
-    "/api/user/register": {
+    "/user/register": {
       post: {
-        tags: ["Register User"],
+        tags: [USER_TAG],
         description: "Registers user",
         operationId: "registeruser",
-        security: [{ bearerAuth: {} }],
+        security: apiKeySecurity,
         requestBody: {
           content: {
             "application/json": {
@@ -348,12 +329,44 @@ const openApiDocumentation = {
         },
       },
     },
-    "/api/user/email-verification/resend": {
+    "/user/active": {
       get: {
-        tags: ["Email resend verification"],
+        tags: [USER_TAG],
+        description: "Registers admin",
+        operationId: "register",
+        security: apiKeySecurity,
+        requestBody: {},
+        parameters: [],
+        responses: {
+          "200": {
+            description: "Success",
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/Response",
+                },
+              },
+            },
+          },
+          "400": {
+            description: "Bad Request",
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/Response",
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    "/user/email-verification/resend": {
+      get: {
+        tags: [USER_TAG],
         description: "email resend varification",
         operationId: "verifyuseremail",
-        security: [{ bearerAuth: {} }],
+        security: apiKeySecurity,
         parameters: [],
         responses: {
           "200": {
@@ -379,12 +392,12 @@ const openApiDocumentation = {
         },
       },
     },
-    "/api/user/enable": {
+    "/user/enable2fa": {
       get: {
-        tags: ["enable 2FA"],
+        tags: [USER_TAG],
         description: "enable 2FA",
         operationId: "enable2FA",
-        security: [{ bearerAuth: {} }],
+        security: apiKeySecurity,
         parameters: [],
         responses: {
           "200": {
@@ -410,12 +423,12 @@ const openApiDocumentation = {
         },
       },
     },
-    "/api/user/login": {
+    "/user/login": {
       post: {
-        tags: ["Login User"],
+        tags: [USER_TAG],
         description: "login user",
         operationId: "loginuser",
-        security: [{ bearerAuth: {} }],
+        security: apiKeySecurity,
         requestBody: {
           content: {
             "application/json": {
@@ -451,12 +464,12 @@ const openApiDocumentation = {
         },
       },
     },
-    "/api/user/verify": {
+    "/user/verify": {
       get: {
-        tags: ["verify OTP"],
+        tags: [USER_TAG],
         description: "verify OTP",
         operationId: "verifyOTP",
-        security: [{ bearerAuth: {} }],
+        security: apiKeySecurity,
         requestBody: {},
         parameters: [],
         responses: {
@@ -483,12 +496,12 @@ const openApiDocumentation = {
         },
       },
     },
-    "/api/user/password/reset": {
+    "/user/password/reset": {
       post: {
-        tags: ["forgot-password"],
+        tags: [USER_TAG],
         description: "Enter your email to reset your password",
         operationId: "forgot-password",
-        security: [{ bearerAuth: {} }],
+        security: apiKeySecurity,
         requestBody: {
           content: {
             "application/json": {
@@ -524,12 +537,12 @@ const openApiDocumentation = {
         },
       },
     },
-    "/api/user/password/{token}": {
+    "/user/password/{token}": {
       patch: {
-        tags: ["reset-password"],
+        tags: [USER_TAG],
         description: "Enter your new password to reset password",
         operationId: "reset-password",
-        security: [{ bearerAuth: {} }],
+        security: apiKeySecurity,
         requestBody: {
           content: {
             "application/json": {
@@ -574,132 +587,136 @@ const openApiDocumentation = {
         },
       },
     },
-    "/api/facebook": {
+    "/user/logout": {
       get: {
-        tags: ["Facebook Auth"],
-        description: "Creates or logs in User through Facebook",
-        operationId: "FacebookAuth",
-        parameters: [],
-        responses: {
-          "200": {
-            description: "Success",
-            content: {
-              "application/json": {
-                schema: {
-                  $ref: "#/components/schemas/Response",
-                },
-              },
-            },
-          },
-          "400": {
-            description: "Bad Request",
-            content: {
-              "application/json": {
-                schema: {
-                  $ref: "#/components/schemas/Response",
-                },
-              },
-            },
-          },
-        },
-      },
-    },
-    "/api/google": {
-      get: {
-        tags: ["Google Auth"],
-        description: "Creates or logs in User through Google",
-        operationId: "googleauth",
-        parameters: [],
-        responses: {
-          "200": {
-            description: "Success",
-            content: {
-              "application/json": {
-                schema: {
-                  $ref: "#/components/schemas/Response",
-                },
-              },
-            },
-          },
-          "400": {
-            description: "Bad Request",
-            content: {
-              "application/json": {
-                schema: {
-                  $ref: "#/components/schemas/Response",
-                },
-              },
-            },
-          },
-        },
-      },
-    },
-    "/api/twitter": {
-      get: {
-        tags: ["Twitter Auth"],
-        description: "Creates or logs in User through Twitter",
-        operationId: "twitterauth",
-        parameters: [],
-        responses: {
-          "200": {
-            description: "Success",
-            content: {
-              "application/json": {
-                schema: {
-                  $ref: "#/components/schemas/Response",
-                },
-              },
-            },
-          },
-          "400": {
-            description: "Bad Request",
-            content: {
-              "application/json": {
-                schema: {
-                  $ref: "#/components/schemas/Response",
-                },
-              },
-            },
-          },
-        },
-      },
-    },
-    "/api/github": {
-      get: {
-        tags: ["Github auth"],
-        description: "github auth",
-        operationId: "github auth",
-        security: [{ bearerAuth: {} }],
-        parameters: [],
-        responses: {
-          "200": {
-            description: "Success",
-            content: {
-              "application/json": {
-                schema: {
-                  $ref: "#/components/schemas/Response",
-                },
-              },
-            },
-          },
-          "400": {
-            description: "Bad Request",
-            content: {
-              "application/json": {
-                schema: {
-                  $ref: "#/components/schemas/Response",
-                },
-              },
-            },
-          },
-        },
-      },
-    },
-    "/api/user/logout": {
-      get: {
-        tags: ["Logout user "],
+        tags: [USER_TAG],
         description: "logout user",
         operationId: "logoutuser",
+        security: apiKeySecurity,
+        parameters: [],
+        responses: {
+          "200": {
+            description: "Success",
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/Response",
+                },
+              },
+            },
+          },
+          "400": {
+            description: "Bad Request",
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/Response",
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    "/facebook": {
+      get: {
+        tags: [AUTH_PROVIDER_TAG],
+        description: "Creates or logs in User through Facebook",
+        operationId: "FacebookAuth",
+        security: apiKeySecurity,
+        parameters: [],
+        responses: {
+          "200": {
+            description: "Success",
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/Response",
+                },
+              },
+            },
+          },
+          "400": {
+            description: "Bad Request",
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/Response",
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    "/google": {
+      get: {
+        tags: [AUTH_PROVIDER_TAG],
+        description: "Creates or logs in User through Google",
+        operationId: "googleauth",
+        security: apiKeySecurity,
+        parameters: [],
+        responses: {
+          "200": {
+            description: "Success",
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/Response",
+                },
+              },
+            },
+          },
+          "400": {
+            description: "Bad Request",
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/Response",
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    "/twitter": {
+      get: {
+        tags: [AUTH_PROVIDER_TAG],
+        description: "Creates or logs in User through Twitter",
+        operationId: "twitterauth",
+        security: apiKeySecurity,
+        parameters: [],
+        responses: {
+          "200": {
+            description: "Success",
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/Response",
+                },
+              },
+            },
+          },
+          "400": {
+            description: "Bad Request",
+            content: {
+              "application/json": {
+                schema: {
+                  $ref: "#/components/schemas/Response",
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    "/github": {
+      get: {
+        tags: [AUTH_PROVIDER_TAG],
+        description: "github auth",
+        operationId: "github auth",
+        security: apiKeySecurity,
         parameters: [],
         responses: {
           "200": {
@@ -727,6 +744,13 @@ const openApiDocumentation = {
     },
   },
   components: {
+    securitySchemes: {
+      Bearer: {
+        type: "http",
+        scheme: "bearer",
+        bearerFormat: "JWT",
+      },
+    },
     schemas: {
       User: {
         type: "object",

--- a/src/utils/CustomError.js
+++ b/src/utils/CustomError.js
@@ -6,4 +6,6 @@ class CustomError extends Error {
   }
 }
 
-module.exports = CustomError;
+module.exports = {
+  CustomError,
+};

--- a/src/utils/CustomError.js
+++ b/src/utils/CustomError.js
@@ -6,6 +6,4 @@ class CustomError extends Error {
   }
 }
 
-module.exports = {
-  CustomError
-};
+module.exports = CustomError;

--- a/src/utils/validation/joiValidation.js
+++ b/src/utils/validation/joiValidation.js
@@ -54,31 +54,38 @@ exports.getSettingsValidation = () => (req, res, next) => {
 };
 
 exports.updateSettingsValidation = () => (req, res, next) => {
-  const schema = Joi.object().keys({
-    email: Joi.string()
-      .email({
-        minDomainSegments: 2,
-        tlds: { allow: true },
-      })
-      .trim()
-      .required(),
-    facebookAuthProvider: Joi.object().keys({
-      appID: Joi.string().required(),
-      appSecret: Joi.string().required(),
-    }),
-    twitterAuthProvider: Joi.object().keys({
-      key: Joi.string().required(),
-      secret: Joi.string().required(),
-    }),
-    githubAuthProvider: Joi.object().keys({
-      clientID: Joi.string().required(),
-      clientSecret: Joi.string().required(),
-    }),
-    googleAuthProvider: Joi.object().keys({
-      clientID: Joi.string().required(),
-      clientSecret: Joi.string().required(),
-    }),
-  });
+  const schema = Joi.object()
+    .keys({
+      email: Joi.string()
+        .email({
+          minDomainSegments: 2,
+          tlds: { allow: true },
+        })
+        .trim()
+        .required(),
+      facebookAuthProvider: Joi.object().keys({
+        appID: Joi.string().required(),
+        appSecret: Joi.string().required(),
+      }),
+      twitterAuthProvider: Joi.object().keys({
+        key: Joi.string().required(),
+        secret: Joi.string().required(),
+      }),
+      githubAuthProvider: Joi.object().keys({
+        clientID: Joi.string().required(),
+        clientSecret: Joi.string().required(),
+      }),
+      googleAuthProvider: Joi.object().keys({
+        clientID: Joi.string().required(),
+        clientSecret: Joi.string().required(),
+      }),
+    })
+    .or(
+      "facebookAuthProvider",
+      "twitterAuthProvider",
+      "githubAuthProvider",
+      "googleAuthProvider"
+    );
   return validator(schema, req.body, res, next);
 };
 

--- a/src/utils/validation/joiValidation.js
+++ b/src/utils/validation/joiValidation.js
@@ -63,7 +63,7 @@ exports.updateSettingsValidation = () => (req, res, next) => {
       .trim()
       .required(),
     facebookAuthProvider: Joi.object().keys({
-      appId: Joi.string().required(),
+      appID: Joi.string().required(),
       appSecret: Joi.string().required(),
     }),
     twitterAuthProvider: Joi.object().keys({
@@ -71,23 +71,13 @@ exports.updateSettingsValidation = () => (req, res, next) => {
       secret: Joi.string().required(),
     }),
     githubAuthProvider: Joi.object().keys({
-      clientId: Joi.string().required(),
+      clientID: Joi.string().required(),
       clientSecret: Joi.string().required(),
     }),
     googleAuthProvider: Joi.object().keys({
-      clientId: Joi.string().required(),
+      clientID: Joi.string().required(),
       clientSecret: Joi.string().required(),
     }),
-  });
-  return validator(schema, req.body, res, next);
-};
-
-exports.updateAuthProvidersValidation = () => (req, res, next) => {
-  const schema = Joi.object().keys({
-    twitterEnabled: Joi.boolean(),
-    facebookEnabled: Joi.boolean(),
-    githubEnabled: Joi.boolean(),
-    googleEnabled: Joi.boolean(),
   });
   return validator(schema, req.body, res, next);
 };

--- a/src/utils/validation/joiValidation.js
+++ b/src/utils/validation/joiValidation.js
@@ -82,6 +82,16 @@ exports.updateSettingsValidation = () => (req, res, next) => {
   return validator(schema, req.body, res, next);
 };
 
+exports.updateAuthProvidersValidation = () => (req, res, next) => {
+  const schema = Joi.object().keys({
+    twitterEnabled: Joi.boolean(),
+    facebookEnabled: Joi.boolean(),
+    githubEnabled: Joi.boolean(),
+    googleEnabled: Joi.boolean(),
+  });
+  return validator(schema, req.body, res, next);
+};
+
 exports.forgotValidation = () => (req, res, next) => {
   const schema = Joi.object().keys({
     email: Joi.string()

--- a/src/utils/validation/joiValidation.js
+++ b/src/utils/validation/joiValidation.js
@@ -1,5 +1,4 @@
-const Joi = require('@hapi/joi');
-
+const Joi = require("@hapi/joi");
 
 const validator = async (schema, toValidate, res, next) => {
   // This middleware will validate client's request body
@@ -19,7 +18,10 @@ exports.registerValidation = () => (req, res, next) => {
       .trim()
       .required(),
     password: Joi.string().min(8).max(20).required(),
-    phone_number: Joi.string().min(10).max(11).pattern(/^[0-9]+$/),
+    phone_number: Joi.string()
+      .min(10)
+      .max(11)
+      .pattern(/^[0-9]+$/),
   });
   return validator(schema, req.body, res, next);
 };
@@ -34,6 +36,35 @@ exports.loginValidation = () => (req, res, next) => {
       .trim()
       .required(),
     password: Joi.string().min(8).max(20).required(),
+  });
+  return validator(schema, req.body, res, next);
+};
+
+exports.updateSettingsValidation = () => (req, res, next) => {
+  const schema = Joi.object().keys({
+    email: Joi.string()
+      .email({
+        minDomainSegments: 2,
+        tlds: { allow: true },
+      })
+      .trim()
+      .required(),
+    facebookAuthProvider: Joi.object().keys({
+      appId: Joi.string().required(),
+      appSecret: Joi.string().required(),
+    }),
+    twitterAuthProvider: Joi.object().keys({
+      key: Joi.string().required(),
+      secret: Joi.string().required(),
+    }),
+    githubAuthProvider: Joi.object().keys({
+      clientId: Joi.string().required(),
+      clientSecret: Joi.string().required(),
+    }),
+    googleAuthProvider: Joi.object().keys({
+      clientId: Joi.string().required(),
+      clientSecret: Joi.string().required(),
+    }),
   });
   return validator(schema, req.body, res, next);
 };
@@ -54,7 +85,7 @@ exports.forgotValidation = () => (req, res, next) => {
 exports.resetPasswordValidation = () => (req, res, next) => {
   const schema = Joi.object().keys({
     password: Joi.string().min(8).max(20).required(),
-    password_confirmation: Joi.any().valid(Joi.ref('password')).required()
+    password_confirmation: Joi.any().valid(Joi.ref("password")).required(),
   });
   return validator(schema, req.body, res, next);
 };

--- a/src/utils/validation/joiValidation.js
+++ b/src/utils/validation/joiValidation.js
@@ -64,20 +64,20 @@ exports.updateSettingsValidation = () => (req, res, next) => {
         .trim()
         .required(),
       facebookAuthProvider: Joi.object().keys({
-        appID: Joi.string().required(),
-        appSecret: Joi.string().required(),
+        appID: Joi.string().allow(null).required(),
+        appSecret: Joi.string().allow(null).required(),
       }),
       twitterAuthProvider: Joi.object().keys({
-        key: Joi.string().required(),
-        secret: Joi.string().required(),
+        key: Joi.string().allow(null).required(),
+        secret: Joi.string().allow(null).required(),
       }),
       githubAuthProvider: Joi.object().keys({
-        clientID: Joi.string().required(),
-        clientSecret: Joi.string().required(),
+        clientID: Joi.string().allow(null).required(),
+        clientSecret: Joi.string().allow(null).required(),
       }),
       googleAuthProvider: Joi.object().keys({
-        clientID: Joi.string().required(),
-        clientSecret: Joi.string().required(),
+        clientID: Joi.string().allow(null).required(),
+        clientSecret: Joi.string().allow(null).required(),
       }),
     })
     .or(

--- a/src/utils/validation/joiValidation.js
+++ b/src/utils/validation/joiValidation.js
@@ -40,6 +40,19 @@ exports.loginValidation = () => (req, res, next) => {
   return validator(schema, req.body, res, next);
 };
 
+exports.getSettingsValidation = () => (req, res, next) => {
+  const schema = Joi.object().keys({
+    email: Joi.string()
+      .email({
+        minDomainSegments: 2,
+        tlds: { allow: true },
+      })
+      .trim()
+      .required(),
+  });
+  return validator(schema, req.body, res, next);
+};
+
 exports.updateSettingsValidation = () => (req, res, next) => {
   const schema = Joi.object().keys({
     email: Joi.string()


### PR DESCRIPTION
**What does this PR do?**

Fixes #497 

**description of Task to be completed?**

- [x] Create Settings model to store the credentials from authentication providers (available options are Facebook, Twitter, Google, and Github).
- [x] Update the Admin model to store a reference to a settings document.
- [x] Add endpoints to get and update settings: GET `/api/admin/settings` and PATCH `/api/admin/settings`.
- [x] Add validation middleware for added admin settings endpoints.
- [x] Add fields in User model to keep track of enabled authentication providers (e.g. `{ googleEnabled: true }`).
- [x] Add endpoint to update user's authentication providers: PATCH `/api/user/providers`.
- [x] Add validation middleware for added user providers endpoint.
- [x] Update passport strategies to accept dynamic credentials.
- [x] Add `authorizeUser` middleware to all settings and social auth endpoints.
- [x] Add `authProvider` middleware to fetch the correct credentials for each social auth endpoint.
- [x] Update social sign in/up endpoints to implement configurable strategies processing requests.
- [x] Make general fixes to the swagger documentation.
- [x] Implement query param to allow documentation to be in JSON format (e.g. `http:localhost:5000/docs?format=json`).

**How should this be manually tested?**

For settings:
- In your terminal, run `npm run dev`.
- In postman, register an admin - POST `/api/admin/register`.
- In postman, get default settings - GET `/api/admin/settings`.
- In postman, update settings - PATCH `/api/admin/settings`.

For using a provider:
- In your terminal, run `npm run dev`.
- In postman, try Twitter sign in - GET `/api/twitter`.
- In postman, try Facebook sign in - GET `/api/facebook`.
- In postman, try GitHub sign in - GET `/api/github`.
- In postman, try Google sign in - GET `/api/google`.

**Any background context you want to provide?**
