### PR TITLE
update: swagger docs servers and request body props

### DIFF
--- a/src/swagger/openApiDocumentation.js
+++ b/src/swagger/openApiDocumentation.js
@@ -18,7 +18,7 @@ const openApiDocumentation = {
   },
   servers: [
     {
-      url: "https://auth-microapi.herokuapp.com/api",
+      url: "https://authentication-microapi.herokuapp.com/api",
       description: "Staging Server (uses test data)",
     },
     {
@@ -138,8 +138,8 @@ const openApiDocumentation = {
             "application/json": {
               schema: {
                 email: {
-                  type: "string"
-                }
+                  type: "string",
+                },
               },
             },
           },
@@ -774,6 +774,10 @@ const openApiDocumentation = {
             type: "string",
             Sdescription: "User phone number",
           },
+          emailVerifyCallbackUrl:{
+            type: "string",
+            description: "Callback url for redirect on email verification",
+          }
         },
       },
       Login: {
@@ -853,6 +857,10 @@ const openApiDocumentation = {
           email: {
             type: "string",
             description: "User Email Address",
+          },
+          emailVerifyCallbackUrl: {
+            type: "string",
+            description: "Callback url for redirect on email verification",
           },
         },
       },

--- a/src/utils/validation/joiValidation.js
+++ b/src/utils/validation/joiValidation.js
@@ -22,7 +22,7 @@ exports.registerValidation = () => (req, res, next) => {
       .min(10)
       .max(11)
       .pattern(/^[0-9]+$/),
-    emailVerifyCallbackUrl: Joi.string().trim(),
+    emailVerifyCallbackUrl: Joi.string().trim().required(),
   });
   return validator(schema, req.body, res, next);
 };


### PR DESCRIPTION
**Before submitting your PR for review**

- Run `npm run lint` to find errors in code syntax/format
- Run `npm run lint:fix` to fix all auto-fixable errors in source code and auto-format with prettier
- Ensure you fix any linting errors displayed after running any of the above commands

**What does this PR do?**

Fixes #513 (replace issue_number with the issue number this PR solves)

The task completed is an update to the documentation to include new request body property of two endpoints and the server to be used for testing from swagger documentation

**description of Task to be completed?**

- [x] Updated servers to be used when testing endpoints from swagger docs.
- [x] Added `emailVerifyCallbackUrl` to the `/user/register` & `/password/forgot-password` endpoints

**How should this be manually tested?**

- Visit the base Url of the api from local or from live server 

**Any background context you want to provide?**

None

**Questions:**

No question
